### PR TITLE
COSTOR-808: Change the FD handling in OPEN

### DIFF
--- a/src/kvsns/include/kvsns/kvsal.h
+++ b/src/kvsns/include/kvsns/kvsal.h
@@ -80,7 +80,7 @@ int kvsal2_exists(void * ctx, char *k, size_t klen);
 int kvsal_set_char(char *k, char *v);
 int kvsal2_set_char(void *ctx, char *k, size_t klen, char *v, size_t vlen);
 int kvsal_get_char(char *k, char *v);
-int kvsal2_get_char(void *ctx, char *k, char *v);
+int kvsal2_get_char(void *ctx, char *k, size_t klen, char *v, size_t vlen);
 int kvsal_set_binary(char *k, char *buf, size_t size);
 int kvsal_get_binary(char *k, char *buf, size_t *size);
 int kvsal_set_stat(char *k, struct stat *buf);

--- a/src/kvsns/include/kvsns/kvsns.h
+++ b/src/kvsns/include/kvsns/kvsns.h
@@ -100,7 +100,7 @@
 
 #define KVSNS_NULL_FS_CTX NULL
 #define KVSNS_FS_ID_DEFAULT 0
-
+#define KVSNS_MAX_FD  4096
 /* KVSAL related definitions and functions */
 
 typedef unsigned long long int kvsns_ino_t;
@@ -130,7 +130,8 @@ typedef struct kvsns_open_owner_ {
 
 typedef struct kvsns_file_open_ {
 	kvsns_ino_t ino;
-	kvsns_open_owner_t owner;
+	kvsns_open_owner_t owner;   // TODO: Remove this while implementing close
+	int fd_index;
 	int flags;
 } kvsns_file_open_t;
 

--- a/src/kvsns/kvsal/mero/kvsal_mero.c
+++ b/src/kvsns/kvsal/mero/kvsal_mero.c
@@ -111,12 +111,8 @@ int kvsal_get_char(char *k, char *v)
 	return m0kvs_get(k, klen, v, &vlen);
 }
 
-int kvsal2_get_char(void *ctx, char *k, char *v)
+int kvsal2_get_char(void *ctx, char *k, size_t klen, char *v, size_t vlen)
 {
-	size_t klen;
-	size_t vlen = VLEN;
-
-	klen = strnlen(k, KLEN)+1;
 	return m0kvs2_get(ctx, k, klen, v, &vlen);
 }
 

--- a/src/kvsns/kvsns/kvsns_internal.h
+++ b/src/kvsns/kvsns/kvsns_internal.h
@@ -57,6 +57,6 @@ int kvsns2_set_stat(void *ctx, kvsns_ino_t *ino, struct stat *bufstat);
 int kvsns_update_stat(kvsns_ino_t *ino, int flags);
 int kvsns_amend_stat(struct stat *stat, int flags);
 int kvsns_delall_xattr(kvsns_cred_t *cred, kvsns_ino_t *ino);
-
+int kvsns_get_fd(void *ctx, kvsns_ino_t *ino, int *fd);
 
 #endif

--- a/src/nfs-ganesha/FSAL_KVSFS/file.c
+++ b/src/nfs-ganesha/FSAL_KVSFS/file.c
@@ -55,6 +55,7 @@ fsal_status_t kvsfs_open(struct fsal_obj_handle *obj_hdl,
 	kvsns_cred_t cred;
 	kvsns_fs_ctx_t fs_ctx = KVSNS_NULL_FS_CTX;
 
+	log_trace("ENTER: ino=%llu fd=%p", myself->handle->kvsfs_handle, &myself->u.file.fd);
 	cred.uid = op_ctx->creds->caller_uid;
 	cred.gid = op_ctx->creds->caller_gid;
 
@@ -71,7 +72,6 @@ fsal_status_t kvsfs_open(struct fsal_obj_handle *obj_hdl,
 
 	rc = kvsns2_open(fs_ctx, &cred, &myself->handle->kvsfs_handle, O_RDWR,
 			 0777, &myself->u.file.fd);
-
 	if (rc)
 		goto errout;
 
@@ -83,6 +83,7 @@ fsal_status_t kvsfs_open(struct fsal_obj_handle *obj_hdl,
 			   &myself->u.file.saved_stat);
 
 errout:
+	log_trace("Exit rc=%d", rc);
 	if (rc) {
 		fsal_error = posix2fsal_error(-rc);
 		return fsalstat(fsal_error, -rc);


### PR DESCRIPTION
The file descriptor information at kvsns should store unique details for
each open, but previous implementation was not storing unique details.
Therefore, changes has been made in the OPEN call to accomodate such
changes.