### PR TITLE
COSTOR-779: Get and set attributes using binary keys.

### DIFF
--- a/src/kvsns/common/mero/m0common.c
+++ b/src/kvsns/common/mero/m0common.c
@@ -433,7 +433,7 @@ out:
 }
 
 int m0kvs_set(char *k, size_t klen,
-	       char *v, size_t vlen)
+	      char *v, size_t vlen)
 {
 	struct m0_bufvec	 key;
 	struct m0_bufvec	 val;

--- a/src/kvsns/include/kvsns/kvsns.h
+++ b/src/kvsns/include/kvsns/kvsns.h
@@ -161,7 +161,6 @@ typedef struct kvsns_str256 {
 
 typedef kvsns_str256_t kvsns_name_t;
 
-
 /** Key val structure definitions and functions */
 typedef enum {
 	KVSNS_VER_0 = 0,
@@ -170,8 +169,9 @@ typedef enum {
 
 typedef enum {
 	KVSNS_KEY_DIRENT = 1,
+	KVSNS_KEY_STAT,
 	KVSNS_KEY_INVALID,
-} kvsns_key_t;
+} kvsns_key_type_t;
 
 typedef struct kvsns_dentry_key_ {
 	kvsns_ino_t  d_inode;
@@ -182,6 +182,11 @@ typedef struct kvsns_dentry_key_ {
 
 typedef kvsns_ino_t kvsns_dentry_val_t;
 
+typedef struct _kvsns_inode_key {
+	kvsns_ino_t k_inode;
+	uint8_t     k_type;
+	uint8_t     k_ver;
+} kvsns_inode_key_t;
 
 /**
  * Generates a key based on variable parameter list.
@@ -274,8 +279,7 @@ int kvsns_access(kvsns_cred_t *cred, kvsns_ino_t *ino, int flags);
  * @return 0 if access is granted, a negative value means an error. -EPERM
  * is returned when access is not granted
  */
-int kvsns2_access(void *ctx, kvsns_cred_t *cred, kvsns_ino_t *ino,
-		  int flags);
+int kvsns2_access(kvsns_fs_ctx_t ctx, kvsns_cred_t *cred, kvsns_ino_t *ino, int flags);
 
 /**
  * Creates a file.
@@ -482,7 +486,7 @@ int kvsns_getattr(kvsns_cred_t *cred, kvsns_ino_t *ino, struct stat *buffstat);
  *
  * @return 0 if successful, a negative "-errno" value in case of failure
  */
-int kvsns2_getattr(void *ctx, kvsns_cred_t *cred, kvsns_ino_t *ino,
+int kvsns2_getattr(kvsns_fs_ctx_t ctx, kvsns_cred_t *cred, kvsns_ino_t *ino,
 		   struct stat *buffstat);
 
 /**
@@ -531,7 +535,7 @@ int kvsns_setattr(kvsns_cred_t *cred, kvsns_ino_t *ino, struct stat *setstat,
  *
  * @return 0 if successful, a negative "-errno" value in case of failure
  */
-int kvsns2_setattr(void *ctx, kvsns_cred_t *cred, kvsns_ino_t *ino,
+int kvsns2_setattr(kvsns_fs_ctx_t ctx, kvsns_cred_t *cred, kvsns_ino_t *ino,
 		   struct stat *setstat, int statflags);
 
 /**

--- a/src/kvsns/kvsns/kvsns_file.c
+++ b/src/kvsns/kvsns/kvsns_file.c
@@ -449,8 +449,6 @@ ssize_t kvsns2_write(void *ctx, kvsns_cred_t *cred, kvsns_file_open_t *fd,
 	int rc;
 	ssize_t write_amount;
 	bool stable;
-	char k[KLEN];
-	size_t klen;
 	struct stat stat;
 	struct stat wstat;
 	kvsns_fid_t kfid;
@@ -477,9 +475,7 @@ ssize_t kvsns2_write(void *ctx, kvsns_cred_t *cred, kvsns_file_open_t *fd,
 	stat.st_mtim = wstat.st_mtim;
 	stat.st_ctim = wstat.st_ctim;
 
-	RC_WRAP_LABEL(rc, out, prepare_key, k, KLEN, "%llu.stat", fd->ino);
-	klen = rc;
-	RC_WRAP(kvsal2_set_stat, ctx, k, klen, &stat);
+	RC_WRAP(kvsns2_ns_set_stat, ctx, &fd->ino, &stat);
 	rc = write_amount;
 out:
 	log_trace("EXIT rc=%d", rc);
@@ -520,8 +516,6 @@ ssize_t kvsns2_read(void *ctx, kvsns_cred_t *cred, kvsns_file_open_t *fd,
 	ssize_t read_amount;
 	bool eof;
 	struct stat stat;
-	char k[KLEN];
-	size_t klen;
 	kvsns_fid_t kfid;
 
 	log_trace("ENTER: ino=%llu fd=%p count=%lu offset=%ld", fd->ino, fd, count, (long)offset);
@@ -535,10 +529,7 @@ ssize_t kvsns2_read(void *ctx, kvsns_cred_t *cred, kvsns_file_open_t *fd,
 		rc = read_amount;
 		goto out;
 	}
-
-	RC_WRAP_LABEL(rc, out, prepare_key, k, KLEN, "%llu.stat", fd->ino);
-	klen = rc;
-	RC_WRAP(kvsal2_set_stat, ctx, k, klen, &stat);
+	RC_WRAP(kvsns2_ns_set_stat, ctx, &fd->ino, &stat);
 	rc = read_amount;
 out:
 	log_trace("EXIT rc=%d", rc);

--- a/src/kvsns/kvsns/kvsns_init.c
+++ b/src/kvsns/kvsns/kvsns_init.c
@@ -134,9 +134,6 @@ int kvsns_init_root(int openbar)
 	bufstat.st_mtim.tv_sec = 0;
 	bufstat.st_ctim.tv_sec = 0;
 
-	memset(k, 0, KLEN);
-	snprintf(k, KLEN, "%llu.stat", ino);
-	RC_WRAP(kvsal_set_stat, k, &bufstat);
-
+	RC_WRAP(kvsns2_ns_set_stat, ctx, &ino, &bufstat);
 	return 0;
 }

--- a/src/kvsns/kvsns/kvsns_internal.h
+++ b/src/kvsns/kvsns/kvsns_internal.h
@@ -51,13 +51,13 @@ int kvsns2_create_entry(void *ctx, kvsns_cred_t *cred, kvsns_ino_t *parent,
 			char *name, char *lnk, mode_t mode, kvsns_ino_t *newdir,
 			enum kvsns_type type);
 int kvsns_get_stat(kvsns_ino_t *ino, struct stat *bufstat);
-int kvsns2_get_stat(void *ctx, kvsns_ino_t *ino, struct stat *bufstat);
+int kvsns2_ns_get_stat(kvsns_fs_ctx_t ctx, kvsns_ino_t *ino, struct stat *bufstat);
 int kvsns_set_stat(kvsns_ino_t *ino, struct stat *bufstat);
-int kvsns2_set_stat(void *ctx, kvsns_ino_t *ino, struct stat *bufstat);
+int kvsns2_ns_set_stat(kvsns_fs_ctx_t ctx, kvsns_ino_t *ino, struct stat *bufstat);
 int kvsns_update_stat(kvsns_ino_t *ino, int flags);
 int kvsns_amend_stat(struct stat *stat, int flags);
 int kvsns_delall_xattr(kvsns_cred_t *cred, kvsns_ino_t *ino);
 int _kvsns_prepare_dirent_key(const kvsns_ino_t dino, const uint8_t namelen,
 			      const char *name, kvsns_dentry_key_t *key);
-
+int _kvsns_ns_prepare_inode_key(const kvsns_key_type_t type, const kvsns_ino_t ino, kvsns_inode_key_t *key);
 #endif


### PR DESCRIPTION
Currently, Setattr and getattr uses stings as keys and value. This
patch converts the strings to binary format.