### PR TITLE
`EOS-211: EOS-NFS: Namespace: Directory creation using KVSNS

### DIFF
--- a/src/kvsns/common/mero/m0common.c
+++ b/src/kvsns/common/mero/m0common.c
@@ -1687,3 +1687,12 @@ ssize_t m0store_get_bsize(struct m0_uint128 id)
 			m0_clovis_layout_id(clovis_instance));
 }
 
+void *m0kvs_alloc(uint64_t size)
+{
+	return m0_alloc(size);
+}
+
+void m0kvs_free(void *ptr)
+{
+	return m0_free(ptr);
+}

--- a/src/kvsns/common/mero/m0common.h
+++ b/src/kvsns/common/mero/m0common.h
@@ -72,6 +72,8 @@ int m0store_create_object(struct m0_uint128 id);
 int m0store_delete_object(struct m0_uint128 id);
 int m0_ufid_get(struct m0_uint128 *ufid);
 int m0_fid_to_string(struct m0_uint128 *fid, char *fid_s);
+void *m0kvs_alloc(uint64_t size);
+void m0kvs_free(void *ptr);
 
 /******************************************************************************/
 /* Key Iterator */

--- a/src/kvsns/include/kvsns/kvsal.h
+++ b/src/kvsns/include/kvsns/kvsal.h
@@ -113,6 +113,9 @@ int kvsal_dispose_list(kvsal_list_t *list);
 int kvsal_init_list(kvsal_list_t *list);
 int kvsal_get_list_size(char *pattern);
 int kvsal2_get_list_size(void *ctx, char *pattern, size_t size);
+int kvsal_create_fs_ctx(unsigned long fs_id, void **fs_ctx);
+int kvsal_alloc(void **ptr, uint64_t size);
+void kvsal_free(void *ptr);
 
 /******************************************************************************/
 /* Key iterator API */

--- a/src/kvsns/kvsal/mero/kvsal_mero.c
+++ b/src/kvsns/kvsal/mero/kvsal_mero.c
@@ -462,3 +462,18 @@ size_t kvsal_iter_get_value(struct kvsal_iter *iter, void **buf)
 	return m0_key_iter_get_value(iter, buf);
 }
 
+int kvsal_alloc(void **ptr, uint64_t size)
+{
+	int rc = 0;
+
+	*ptr = m0kvs_alloc(size);
+	if (ptr == NULL)
+		rc = -ENOMEM;
+
+	return rc;
+}
+
+void kvsal_free(void *ptr)
+{
+	return m0kvs_free(ptr);
+}


### PR DESCRIPTION
- Use preallocated buffers for key values for directory creation.
- Fixed memory leaks by implementing kvsal_alloc and kvsal_free functions

Change-Id: I1a53c28de9c95af60a6c79e07a34b9cbd20efd8e

Closes EOS-211