### PR TITLE
EOS-695: Fixed KVSNS RPM spec file

### DIFF
--- a/src/kvsns/libkvsns.spec-in.cmake
+++ b/src/kvsns/libkvsns.spec-in.cmake
@@ -100,10 +100,10 @@ install -m 644 common/mero/libm0common.so %{buildroot}%{_libdir}
 install -m 644 libkvsns.pc  %{buildroot}%{_libdir}/pkgconfig
 install -m 755 kvsns_shell/kvsns_ns %{buildroot}%{_bindir}
 install -m 644 kvsns.ini %{buildroot}%{_sysconfdir}/kvsns.d
-ln -s -f %{_bindir}/kvsns_ns %{_bindir}/kvsns_init
-ln -s -f %{_bindir}/kvsns_ns %{_bindir}/kvsns_create
-ln -s -f %{_bindir}/kvsns_ns %{_bindir}/kvsns_getattr
-ln -s -f %{_bindir}/kvsns_ns %{_bindir}/kvsns_setattr
+ln -s -f %{_bindir}/kvsns_ns %{buildroot}%{_bindir}/kvsns_init
+ln -s -f %{_bindir}/kvsns_ns %{buildroot}%{_bindir}/kvsns_create
+ln -s -f %{_bindir}/kvsns_ns %{buildroot}%{_bindir}/kvsns_getattr
+ln -s -f %{_bindir}/kvsns_ns %{buildroot}%{_bindir}/kvsns_setattr
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -126,6 +126,10 @@ rm -rf $RPM_BUILD_ROOT
 %files utils
 %defattr(-,root,root)
 %{_bindir}/kvsns_ns
+%{_bindir}/kvsns_init
+%{_bindir}/kvsns_create
+%{_bindir}/kvsns_getattr
+%{_bindir}/kvsns_setattr
 
 %changelog
 * Thu Jun 13 2017 Philippe DENIEL <philippe.deniel@cea.fr> 1.2.0


### PR DESCRIPTION
Symlinks were not created in the build root dir and the symlinks
were not in the package files list.