### PR TITLE
EOS-912: Add implementation of the Unchecked4 create mode

### DIFF
--- a/src/kvsns/kvsns/kvsns_handle.c
+++ b/src/kvsns/kvsns/kvsns_handle.c
@@ -680,12 +680,7 @@ int kvsns2_unlink(void *ctx, kvsns_cred_t *cred, kvsns_ino_t *dir, char *name)
 	RC_WRAP_LABEL(rc, errfree, kvsns2_get_stat, ctx, &ino, &ino_stat);
 
 	/* Check if the file is opened */
-	RC_WRAP_LABEL(rc, errfree, prepare_key, k, KLEN, "%llu.openowner.*", ino);
-	rc = kvsal2_exists(ctx, k, KLEN);
-	if ((rc != 0) && (rc != -ENOENT))
-		goto aborted;
-
-	opened = (rc == -ENOENT) ? false : true;
+	RC_WRAP_LABEL(rc, errfree, kvsns_is_open, ctx, NULL, &ino, &opened);
 
 	RC_WRAP(kvsal_begin_transaction);
 

--- a/src/kvsns/kvsns/kvsns_internal.c
+++ b/src/kvsns/kvsns/kvsns_internal.c
@@ -745,6 +745,13 @@ out:
 int kvsns2_set_stat(kvsns_fs_ctx_t ctx, const kvsns_ino_t *ino,
 		    struct stat *bufstat)
 {
+	assert(bufstat != NULL);
+
+	log_trace("set_stat(%llu), uid: %d, gid: %d, mode: %04o",
+		  (unsigned long long) *ino,
+		  bufstat->st_uid,
+		  bufstat->st_gid,
+		  bufstat->st_mode & 07777);
 	return kvsns_ns_set_inode_attr(ctx, ino, KVSNS_KEY_TYPE_STAT,
 				       bufstat, sizeof(*bufstat));
 }

--- a/src/kvsns/kvsns_shell/kvsns_busybox.c
+++ b/src/kvsns/kvsns_shell/kvsns_busybox.c
@@ -120,18 +120,6 @@ int main(int argc, char *argv[])
 			fprintf(stderr, "kvsns_init_root: err=%d\n", rc);
 			exit(1);
 		}
-	} else if (!strcmp(exec_name, "ns_creat")) {
-		if (argc != 2) {
-			fprintf(stderr, "creat <newfile>\n");
-			exit(1);
-		}
-		rc = kvsns_creat(&cred, &current_inode, argv[1], 0755, &ino);
-		if (rc == 0) {
-			printf("==> %llu/%s created = %llu\n",
-				current_inode, argv[1], ino);
-			return 0;
-		} else
-			printf("Failed rc=%d !\n", rc);
 	} else if (!strcmp(exec_name, "ns_rmdir")) {
 		if (argc != 2) {
 			fprintf(stderr, "rmdir <newdir>\n");

--- a/src/kvsns/kvsns_shell/kvsns_cp.c
+++ b/src/kvsns/kvsns_shell/kvsns_cp.c
@@ -127,12 +127,18 @@ int main(int argc, char *argv[])
 	if (kvsns_dest) {
 		rc = kvsns_lookup_path(&cred, &parent, dest, &ino);
 		if (rc == -2) {
+			/* This utility does not support the multi-index
+			 * KVSNS API */
+#if 0
 			rc = kvsns_creat(&cred, &parent, dest, 0644, &ino);
+#endif
 			exit_rc("Can't create dest file in KVSNS", rc);
 		} else
 			exit_rc("Can't lookup dest in KVSNS", rc);
 
+#if 0
 		rc = kvsns_open(&cred, &ino, O_WRONLY, 0644, &kfd);
+#endif
 	}
 	exit_rc("Can't open file in KVSNS", rc);
 
@@ -149,8 +155,9 @@ int main(int argc, char *argv[])
 	rc = close(fd);
 	exit_rc("Can't close POSIX fd, errno=%d", errno);
 
+#if 0
 	rc = kvsns_close(&kfd);
 	exit_rc("Can't close KVSNS fd, errno=%d", errno);
-
+#endif
 	return 0;
 }

--- a/src/kvsns/kvsns_shell/kvsns_ns.c
+++ b/src/kvsns/kvsns_shell/kvsns_ns.c
@@ -296,7 +296,7 @@ int main(int argc, char *argv[])
 			exit (1);
 		}
 
-		rc = kvsns2_creat(fs_ctx, &cred, &current_inode, argv[1], 0755, &ino);
+		rc = kvsns_creat(fs_ctx, &cred, &current_inode, argv[1], 0755, &ino);
 		if (rc == 0) {
 			printf("==> %llu/%s created = %llu\n",
 				current_inode, argv[1], ino);

--- a/src/kvsns/tests/kvsns_file_test_rw.c
+++ b/src/kvsns/tests/kvsns_file_test_rw.c
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
 	}
 
 	parent = KVSNS_ROOT_INODE;
-	rc = kvsns2_creat(fs_ctx, &cred, &parent, "fichier", 0755, &ino);
+	rc = kvsns_creat(fs_ctx, &cred, &parent, "fichier", 0755, &ino);
 	if (rc != 0) {
 		if (rc == -EEXIST)
 			fprintf(stderr, "dirent exists\n");
@@ -91,12 +91,17 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	/* kvsns_open is not implemeted yet */
+#if 0
 	rc = kvsns2_open(fs_ctx, &cred, &ino, 0 /* to raise errors laters */,
 			 0755, &fd);
 	if (rc != 0) {
 		fprintf(stderr, "kvsns_open: err=%d\n", rc);
 		exit(1);
 	}
+#else
+	assert(0);
+#endif
 
 	strncpy(buff, "This is the content of the file", SIZE);
 	count = strnlen(buff, SIZE);
@@ -125,11 +130,13 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
+#if 0
 	rc = kvsns2_close(fs_ctx, &fd);
 	if (rc != 0) {
 		fprintf(stderr, "kvsns_close: err=%d\n", rc);
 		exit(1);
 	}
+#endif
 
 	printf("######## OK ########\n");
 	return 0;

--- a/src/kvsns/tests/kvsns_file_test_unlink_on_close.c
+++ b/src/kvsns/tests/kvsns_file_test_unlink_on_close.c
@@ -44,6 +44,10 @@
 
 int main(int argc, char *argv[])
 {
+	/* Delete-on-close (a.k.a last reference principle) is not supported
+	 * at the kvsns layer (yet) */
+	return -1;
+#if 0
 	int rc;
 	kvsns_ino_t ino = 0LL;
 	kvsns_ino_t parent = 0LL;
@@ -131,5 +135,5 @@ int main(int argc, char *argv[])
 
 	printf("######## OK ########\n");
 	return 0;
-
+#endif
 }


### PR DESCRIPTION
The patch implements handling of O_CREAT (see `man 2 open`) : 
* `(O_CREAT | O_TRUNC)` also can be handled now by the open2 but the file won't be actually truncated in this case (O_TRUNC will be implemented in EOS-914). 
* `(O_CREAT | O_EXCL)` is not supported and returns ENOTSUP (O_EXCL will be implemented in EOS-913).
* So that, only the `(O_CREAT | O_APPEND)` is the mode which is fully supported by this patch.

See testing results [here](https://jts.seagate.com/browse/EOS-912?focusedCommentId=1697703&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1697703).



Closes: EOS-912