### PR TITLE
EOS-NFS: EOS-223: NFS IO: KVSNS Write operation

### DIFF
--- a/src/kvsns/include/kvsns/extstore.h
+++ b/src/kvsns/include/kvsns/extstore.h
@@ -48,9 +48,7 @@
 
 int extstore_init(struct collection_item *cfg_items);
 int extstore_create(kvsns_ino_t object);
-int extstore2_create(void *ctx,
-		     kvsns_ino_t object,
-		     kvsns_fid_t *fid);
+int extstore2_create(void *ctx, kvsns_fid_t *fid);
 int extstore_read(kvsns_ino_t *ino,
 		  off_t offset,
 		  size_t buffer_size,
@@ -69,14 +67,13 @@ int extstore_write(kvsns_ino_t *ino,
 int extstore2_write(void *ctx, kvsns_fid_t *kfid, off_t offset, size_t buffer_size,
 		    void *buffer, bool *fsal_stable, struct stat *stat);
 int extstore_del(kvsns_ino_t *ino);
-int extstore2_del(void *ctx, kvsns_ino_t *ino, kvsns_fid_t *fid);
+int extstore2_del(void *ctx, kvsns_fid_t *fid);
 int extstore_truncate(kvsns_ino_t *ino,
 		      off_t filesize,
 		      bool on_obj_store,
 		      struct stat *stat);
 int extstore_attach(kvsns_ino_t *ino,
 		    char *objid, int objid_len);
-int extstore_get_fid(kvsns_ino_t object,
-		     kvsns_fid_t *fid);
+int extstore_get_new_kfid(kvsns_ino_t ino, kvsns_fid_t *kfid);
 int extstore_ino_to_fid(void *ctx, kvsns_ino_t object, kvsns_fid_t *fid);
 #endif

--- a/src/kvsns/kvsns/kvsns_handle.c
+++ b/src/kvsns/kvsns/kvsns_handle.c
@@ -729,8 +729,9 @@ int kvsns2_unlink(void *ctx, kvsns_cred_t *cred, kvsns_ino_t *dir, char *name)
 	 *	it has no more links in the fs tree
 	 */
 	if (!opened && !S_ISLNK(ino_stat->st_mode) && (size == 1)) {
-		RC_WRAP(extstore_ino_to_fid, ctx, ino, &kfid);
-		RC_WRAP(extstore2_del, ctx, &ino, &kfid);
+		RC_WRAP(kvsns_ino_to_kfid, ctx, &ino, &kfid);
+		RC_WRAP(extstore2_del, ctx, &kfid);
+		RC_WRAP(kvsns_del_kfid, ctx, &ino);
 	}
 
 errfree:

--- a/src/kvsns/kvsns/kvsns_internal.h
+++ b/src/kvsns/kvsns/kvsns_internal.h
@@ -171,4 +171,13 @@ int kvsns_tree_iter_children(kvsns_fs_ctx_t fs_ctx,
 			     void *cb_ctx);
 
 /******************************************************************************/
+/** Set the extstore object identifier (kfid) with kvsns inode as the key */
+int kvsns_set_ino_kfid(void *ctx, kvsns_ino_t *ino, kvsns_fid_t *kfid);
+
+/** Get the extstore object identifier for the passed kvsns inode */
+int kvsns_ino_to_kfid(void *ctx, kvsns_ino_t *ino, kvsns_fid_t *kfid);
+
+/** Delete the ino-kfid key-val pair from the kvs. Called during unlink/rm. */
+int kvsns_del_kfid(void *ctx, kvsns_ino_t *ino);
+
 #endif


### PR DESCRIPTION
-Modified the kvsns_ino-to-fid keys from  the "text" format (inode.data) to "binary" format
- Added  the alloc, set  get init and free for these keys and values.
- Moved the operations on kvsns_ino-to-fid key-vals from extstore to kvsal.
This is required because all the namespace operations should be part of the KVS
and not extstore. The extstore apis should perform io operations on passed fid
(or a object identifier/handle) that identifies an object in the backing store.

Change-Id: I513979dbd9d17326349c8574b222897b10002577

Closes EOS-223