### PR TITLE
EOS-912: Allow O_TRUNC as an argument for kvsns_create_unchecked.

### DIFF
--- a/src/nfs-ganesha/FSAL_KVSFS/handle.c
+++ b/src/nfs-ganesha/FSAL_KVSFS/handle.c
@@ -1651,9 +1651,6 @@ kvsfs_create_unchecked(struct fsal_obj_handle *parent_obj_hdl, const char *name,
 	assert(name != NULL);
 	assert(state && parent_obj_hdl);
 
-	/* create operations do not support the truncate flag */
-	assert((openflags & FSAL_O_TRUNC) == 0);
-
 	parent_obj = container_of(parent_obj_hdl,
 				  struct kvsfs_fsal_obj_handle, obj_handle);
 


### PR DESCRIPTION
Since the client does not know if the file exists or not,
it is free to set size=0 fattr in the OPEN4 call.
Thus, let's remove the restriction where we assume that
kvsns_create_unchecked cannot be called with O_TRUNC set.

Closes: EOS-912