### PR TITLE
EOS-1489: Fix dir listing for 255-byte entries.

### DIFF
--- a/src/kvsns/tests/kvsns_readdir_tests.sh
+++ b/src/kvsns/tests/kvsns_readdir_tests.sh
@@ -201,4 +201,27 @@ test_kvsns_readdir_multiple_files() {
 }
 
 ################################################################################
+# Description: List contents of a directory which has 255-bytes entry names
+# Strategy:
+#   Create a file with a 255 characters name in the root dir.
+#   Get list of entries of the root dir.
+# Expected behavior:
+#   The file is in the list.
+test_kvsns_readdir_root_dir_255file() {
+    # bash equivalent of print('a' * 255)
+    local file_name="$(printf 'a%.0s' {1..255})"
+    local parent_ino="$KVSNS_ROOT_INODE"
+    local parent="/"
+
+    kvsns_prepare_clean_index
+
+    test_setup kvsns_create_cmd $parent $file_name
+    test_setup kvsns_lookup_cmd $parent $file_name
+
+    test_verify_ok kvsns_readdir_cmd $parent_ino
+
+    test_verify_ok readdir_check_single_file $parent_ino $file_name
+
+    test_teardown kvsns_unlink_cmd $parent $file_name
+}
 

--- a/src/kvsns/tests/kvsns_test_list.sh
+++ b/src/kvsns/tests/kvsns_test_list.sh
@@ -47,6 +47,7 @@ TGROUP_READDIR=(
     test_kvsns_readdir_file_and_dir
     test_kvsns_readdir_empty_dir
     test_kvsns_readdir_multiple_files
+    test_kvsns_readdir_root_dir_255file
 )
 
 ################################################################################


### PR DESCRIPTION
1. Fix post-condition for dentry key.
2. Fix the dynamic size of a kvsns string.
3. Add an FT for READDIR operation on 255-byte entries.

Closes: EOS-1489