### PR TITLE
EOS-234: Add truncate() implementation.

### DIFF
--- a/src/kvsns/common/mero/m0common.h
+++ b/src/kvsns/common/mero/m0common.h
@@ -146,6 +146,24 @@ ssize_t m0store_get_bsize(struct m0_uint128 id);
 ssize_t m0store_do_io(struct m0_uint128 id, enum io_type iotype, off_t x,
 		      size_t len, size_t bs, char *buff);
 
+/* Deallocates space allocated for `fid` in the range specified by
+ * `count` and `offset` -- the first deallocated byte is fid[offset]
+ * and the last deallocated byte is fid[offset + count - 1].
+ * If the range is not properly aligned with the block size of the
+ * underlying storage then either block space is filled with zeros (1) or
+ * block is deleted (2), or both (1+2).
+ *
+ *  1.     | block1 | block2 | <- no deallocations
+ *	      |00000| <- added zeros instead of data
+ *
+ *  2.     | block1 | block2 | < block2 is deallocated
+ *                  |   |
+ *
+ *  1+2.   | block1 | block2 | <- block2 is deallocated
+ *            |00000    | <- AND zeros instead of data for block1
+ */
+int m0_file_unmap(struct m0_uint128 fid, size_t count, off_t offset);
+
 static inline ssize_t m0store_pwrite(struct m0_uint128 id, off_t x,
 				     size_t len, size_t bs, char *buff)
 {

--- a/src/kvsns/include/kvsns/extstore.h
+++ b/src/kvsns/include/kvsns/extstore.h
@@ -72,6 +72,10 @@ int extstore_truncate(kvsns_ino_t *ino,
 		      off_t filesize,
 		      bool on_obj_store,
 		      struct stat *stat);
+int extstore2_truncate(void *ctx,
+		       kvsns_fid_t *fid,
+		       size_t old_size,
+		       size_t new_size);
 int extstore_attach(kvsns_ino_t *ino,
 		    char *objid, int objid_len);
 int extstore_get_new_kfid(kvsns_ino_t ino, kvsns_fid_t *kfid);

--- a/src/kvsns/include/kvsns/kvsns.h
+++ b/src/kvsns/include/kvsns/kvsns.h
@@ -525,6 +525,19 @@ int kvsns2_getattr(kvsns_fs_ctx_t ctx, kvsns_cred_t *cred, kvsns_ino_t *ino,
 int kvsns_setattr(kvsns_cred_t *cred, kvsns_ino_t *ino, struct stat *setstat,
 		 int statflags);
 
+/** Change size of a file.
+ * Changes the size unmapping unused storage space in case of truncation.
+ * The function is able to apply a set of new stat values along with
+ * the new file size value.
+ * @param ctx - Filesystem context.
+ * @param ino - Inode of the file.
+ * @param new_stat - A set of stat values to be set.
+ * @param new_stat_flags - A set of flags which defines which stat values
+ *	  have to be updated. STAT_SIZE_SET is a required flag.
+ * @return 0 if successful, a negative "-errno" value in case of failure.
+ */
+int kvsns_truncate(kvsns_fs_ctx_t ctx, kvsns_cred_t *cred, kvsns_ino_t *ino,
+		   struct stat *new_stat, int new_stat_flags);
 /**
  * Sets attributes for a known inode.
  *
@@ -534,7 +547,7 @@ int kvsns_setattr(kvsns_cred_t *cred, kvsns_ino_t *ino, struct stat *setstat,
  *  STAT_MODE_SET: sets mode
  *  STAT_UID_SET: sets owner
  *  STAT_GID_SET: set group owner
- *  STAT_SIZE_SET: set size (aka truncate)
+ *  STAT_SIZE_SET: set size (aka truncate but without unmapping)
  *  STAT_ATIME_SET: sets atime
  *  STAT_MTIME_SET: sets mtime
  *  STAT_CTIME_SET: set ctime

--- a/src/kvsns/kvsns/kvsns_handle.c
+++ b/src/kvsns/kvsns/kvsns_handle.c
@@ -471,20 +471,21 @@ int kvsns2_setattr(kvsns_fs_ctx_t ctx, kvsns_cred_t *cred, kvsns_ino_t *ino,
 		bufstat.st_mode = setstat->st_mode | ifmt;
 	}
 
-	if (statflag & STAT_UID_SET)
+	if (statflag & STAT_UID_SET) {
 		bufstat.st_uid = setstat->st_uid;
+	}
 
-	if (statflag & STAT_GID_SET)
+	if (statflag & STAT_GID_SET) {
 		bufstat.st_gid = setstat->st_gid;
+	}
 
-	/* @todo : Truncate is not implemented for for kvsns2 yet. */
-	if (statflag & STAT_SIZE_SET)
-		RC_WRAP_LABEL(rc, out, extstore_truncate, ino, setstat->st_size, true,
-			      &bufstat);
+	if (statflag & STAT_SIZE_SET) {
+		bufstat.st_size = setstat->st_size;
+	}
 
-	if (statflag & STAT_SIZE_ATTACH)
-		RC_WRAP_LABEL(rc, out, extstore_truncate, ino, setstat->st_size, false,
-			       &bufstat);
+	if (statflag & STAT_SIZE_ATTACH) {
+		KVSNS_DASSERT(0); /* Unsupported */
+	}
 
 	if (statflag & STAT_ATIME_SET) {
 		bufstat.st_atim.tv_sec = setstat->st_atim.tv_sec;

--- a/src/kvsns/kvsns_shell/CMakeLists.txt
+++ b/src/kvsns/kvsns_shell/CMakeLists.txt
@@ -82,6 +82,8 @@ add_custom_command(TARGET links
 		   COMMAND ${CMAKE_COMMAND} -E create_symlink kvsns_ns kvsns_link
 		   COMMAND ${CMAKE_COMMAND} -E remove kvsns_rmdir
 		   COMMAND ${CMAKE_COMMAND} -E create_symlink kvsns_ns kvsns_rmdir
+		   COMMAND ${CMAKE_COMMAND} -E remove kvsns_trunc
+		   COMMAND ${CMAKE_COMMAND} -E create_symlink kvsns_ns kvsns_trunc
 
 		   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		   VERBATIM)


### PR DESCRIPTION
KVSNS: Adds kvsns_truncate() implementation.

KVSNS utils: Adds `kvsns_trunc` command.

KVSFS: Uses kvsns_truncate() call.

[Link](https://jts.seagate.com/browse/EOS-234?focusedCommentId=1716464&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1716464) the results of testing with a single NFS Client and small files (<4K).

Closes: EOS-234