### PR TITLE
EOS-1820: Enable Clovis Deallocation.

### DIFF
--- a/src/kvsns/kvsns/kvsns_handle.c
+++ b/src/kvsns/kvsns/kvsns_handle.c
@@ -481,6 +481,7 @@ int kvsns2_setattr(kvsns_fs_ctx_t ctx, kvsns_cred_t *cred, kvsns_ino_t *ino,
 
 	if (statflag & STAT_SIZE_SET) {
 		bufstat.st_size = setstat->st_size;
+		bufstat.st_blocks = setstat->st_blocks;
 	}
 
 	if (statflag & STAT_SIZE_ATTACH) {


### PR DESCRIPTION
* Enables usage of the M0_CLOVIS_OC_FREE in m0common.
* Adds a batching mechanism to send small portions of extents
    in order to prevent the case where we might get a timeout
    from Clovis or an error. It is an ad-hoc solution
    and it might be removed in future.

Closes: EOS-1820