### PR TITLE
EOS-2615: get_clovis_conf() called 2 times in m0kvs_do_init()

### DIFF
--- a/src/kvsns/common/mero/m0common.c
+++ b/src/kvsns/common/mero/m0common.c
@@ -133,8 +133,8 @@ static int init_clovis(void)
 	int rc;
 	char  tmpfid[MAXNAMLEN];
 
-
-	assert(clovis_local_addr && clovis_ha_addr && clovis_prof && clovis_proc_fid);
+	assert(clovis_local_addr && clovis_ha_addr && clovis_prof &&
+	       clovis_proc_fid);
 
 	/* Initialize Clovis configuration */
 	clovis_conf.cc_is_oostore	= true;


### PR DESCRIPTION
Closes EOS-2615