### PR TITLE
EOS-2705 : Build failure - Change in kvsns2_unlink api

### DIFF
--- a/src/kvsns/test/op/unlink.c
+++ b/src/kvsns/test/op/unlink.c
@@ -79,7 +79,7 @@ int op_unlink(void *ctx, void *cred, int argc, char *argv[])
 	printf("Removing File  = [%s].\n", fname);
 
 	RC_LOG_NOTEQ(rc, STATUS_OK, error, kvsns2_unlink,
-			fs_ctx, user_cred, &dir_inode, fname);
+			fs_ctx, user_cred, &dir_inode, NULL, fname);
 
 	printf("Removed File  = [%s].\n", fname);
 


### PR DESCRIPTION
Build Failure due to change in kvsns2_unlink api and test framework merge.