### PR TITLE
EOS-2313: Checking in experiment code. Now it is dependent on EOS-3131.

### DIFF
--- a/experiments/m0trace/README
+++ b/experiments/m0trace/README
@@ -1,0 +1,36 @@
+1. Add following code in src/kvsns/kvsns/kvsns_init.c
+   #include <lib/trace.h>
+- In kvsns_start(...) function
+   m0_trace_set_immediate_mask("all");
+   m0_trace_set_print_context("full");
+   m0_trace_set_level("DEBUG");
+   M0_LOG(M0_DEBUG, "kvsns init Successful");
+
+2. Add following code in src/kvsns/kvsns/CMakeLists.txt
+   set(MERO_CFLAGS "-D_REENTRANT -D_GNU_SOURCE -DM0_INTERNAL='' -DM0_EXTERN=extern ")
+   set(MERO_CFLAGS "${MERO_CFLAGS} -Wall -Werror -Wno-attributes -Wno-unused-but-set-variable ")
+   set(MERO_CFLAGS "${MERO_CFLAGS} -I/usr/include/mero ")
+
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${MERO_CFLAGS}")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MERO_CFLAGS}")
+
+3. Change directory to /tmp/kvsns_build/kvsns_shell
+Run make to build modified source code
+
+4. Run ./kvsns_init
+5. Step 4 generates the m0trace.<pid> in binary format.
+6. Change directory to eos-fs/experiments/m0trace
+   - Build kvsns_trace_dump.c using following command
+gcc -Wall -D_REENTRANT -D_GNU_SOURCE -DM0_INTERNAL='' -DM0_EXTERN=extern -Werror -Wno-attributes -Wno-unused-but-set-variable -I/usr/include/mero kvsns_trace_dump.c -o kvsns_trace_dump -L/lib64/ -lmero -lkvsns -m64
+7. sudo ./kvsns_trace_dump -i m0_trace.<pid> -o <Output file>
+8. Open Output file
+Failed to show the M0_LOG message added in kvsns_init.c file. Other messages from mero library can be seen in this file.
+
+
+Note:
+There is another m0_log.c file in experiments/m0trace folder. It also logs message in m0trace.<pid> file using mero library. kvsns_trace_dump executable should be able to access to m0_log symbols. To build m0_log.c run following command
+gcc -Wall -D_REENTRANT -D_GNU_SOURCE -DM0_INTERNAL='' -DM0_EXTERN=extern -Werror -Wno-attributes -Wno-unused-but-set-variable -I/usr/include/mero m0_log.c -o m0_log -L/lib64/ -lmero -m64
+
+After the completion of ticket EOS-3131:
+1. Change m0_trace_parse call in kvsns_trace_dump.c file. Need to pass trace descriptor offset in m0_trace_parse call.
+2. Should be able to successfully show the log message added in the kvsns_init.c file

--- a/experiments/m0trace/kvsns_trace_dump.c
+++ b/experiments/m0trace/kvsns_trace_dump.c
@@ -1,0 +1,160 @@
+/* -*- C -*- */
+/*
+ * COPYRIGHT 2013 XYRATEX TECHNOLOGY LIMITED
+ *
+ * THIS DRAWING/DOCUMENT, ITS SPECIFICATIONS, AND THE DATA CONTAINED
+ * HEREIN, ARE THE EXCLUSIVE PROPERTY OF XYRATEX TECHNOLOGY
+ * LIMITED, ISSUED IN STRICT CONFIDENCE AND SHALL NOT, WITHOUT
+ * THE PRIOR WRITTEN PERMISSION OF XYRATEX TECHNOLOGY LIMITED,
+ * BE REPRODUCED, COPIED, OR DISCLOSED TO A THIRD PARTY, OR
+ * USED FOR ANY PURPOSE WHATSOEVER, OR STORED IN A RETRIEVAL SYSTEM
+ * EXCEPT AS ALLOWED BY THE TERMS OF XYRATEX LICENSES AND AGREEMENTS.
+ *
+ * YOU SHOULD HAVE RECEIVED A COPY OF XYRATEX'S LICENSE ALONG WITH
+ * THIS RELEASE. IF NOT PLEASE CONTACT A XYRATEX REPRESENTATIVE
+ * http://www.xyratex.com/contact
+ *
+ * Original author: Dmitriy Chumak <dmitriy_chumak@xyratex.com>
+ * Original creation date: 12-Dec-2012
+ */
+
+
+#include <stdio.h>      /* printf */
+#include <err.h>        /* err */
+#include <errno.h>      /* errno */
+#include <string.h>     /* strcpy, basename */
+#include <sysexits.h>   /* EX_* exit codes (EX_OSERR, EX_SOFTWARE) */
+
+#include "module/instance.h"       /* m0 */
+#include "mero/init.h"             /* m0_init */
+#include "lib/uuid.h"              /* m0_node_uuid_string_set */
+#include "lib/getopts.h"           /* M0_GETOPTS */
+#include "lib/thread.h"            /* LAMBDA */
+#include "lib/string.h"            /* m0_strdup */
+#include "lib/user_space/types.h"  /* bool */
+#include "lib/user_space/trace.h"  /* m0_trace_parse */
+#include "lib/misc.h"              /* ARRAY_SIZE */
+
+
+#define DEFAULT_M0MERO_KO_IMG_PATH  "/var/log/mero/m0mero_ko.img"
+
+int main(int argc, char *argv[])
+{
+	static struct m0 instance;
+
+	const char  std_inout_file_name[] = "-";
+	const char *input_file_name       = std_inout_file_name;
+	const char *output_file_name      = std_inout_file_name;
+	const char *m0mero_ko_path        = DEFAULT_M0MERO_KO_IMG_PATH;
+	FILE       *input_file;
+	FILE       *output_file;
+	bool        stream_mode           = true;
+	bool        dump_header_only      = false;
+	int         rc;
+
+	/* prevent creation of trace file for ourselves */
+	m0_trace_set_mmapped_buffer(false);
+
+	/* we don't need a real node uuid, so we force a default one to be useed
+	 * instead */
+	m0_node_uuid_string_set(NULL);
+
+	rc = m0_init(&instance);
+	if (rc != 0)
+		return EX_SOFTWARE;
+
+	/* process CLI options */
+	rc = M0_GETOPTS(basename(argv[0]), argc, argv,
+	  M0_HELPARG('h'),
+	  M0_STRINGARG('i',
+		"input file name, if none is provided, then STDIN is used by"
+		" default",
+		LAMBDA(void, (const char *str) {
+			input_file_name = m0_strdup(str);
+		})
+	  ),
+	  M0_STRINGARG('o',
+		"output file name, if none is provided, then STDOUT is used by"
+		" default",
+		LAMBDA(void, (const char *str) {
+			output_file_name = m0_strdup(str);
+		})
+	  ),
+	  M0_VOIDARG('s',
+		  "stream mode, each trace record is formatted as a"
+		  " separate YAML document, so they can be fetched from"
+		  " YAML stream one by one (this option has no effect as it's"
+		  " 'on' by default, it has been kept for backward"
+		  " compatibility, it's superseded by '-S' option)",
+		  LAMBDA(void, (void) { })
+	  ),
+	  M0_VOIDARG('S',
+		  "disable stream mode (discards action of '-s' option)",
+		  LAMBDA(void, (void) {
+			  stream_mode = false;
+		  })
+	  ),
+	  M0_FLAGARG('H',
+		  "dump only trace header information",
+		  &dump_header_only
+	  ),
+	  M0_STRINGARG('k',
+		"path to m0mero.ko modules's core image (only required for"
+		" parsing kernel mode trace files), by default it is '"
+		DEFAULT_M0MERO_KO_IMG_PATH "'",
+		LAMBDA(void, (const char *str) {
+			m0mero_ko_path = m0_strdup(str);
+		})
+	  ),
+	);
+
+	if (rc != 0)
+		return EX_USAGE;
+
+	/* open input file */
+	if (strcmp(input_file_name, std_inout_file_name) == 0) {
+		input_file = stdin;
+	} else {
+		input_file = fopen(input_file_name, "r");
+		if (input_file == NULL)
+			err(EX_NOINPUT, "Failed to open input file '%s'",
+					input_file_name);
+	}
+
+	/* open output file */
+	if (strcmp(output_file_name, std_inout_file_name) == 0) {
+		output_file = stdout;
+	} else {
+		output_file = fopen(output_file_name, "w");
+		if (output_file == NULL)
+			err(EX_CANTCREAT, "Failed to open output file '%s'",
+					  output_file_name);
+	}
+
+	rc = m0_trace_parse(input_file, output_file, stream_mode,
+			    dump_header_only, m0mero_ko_path);
+	if (rc != 0) {
+		warnx("Error occurred while parsing input trace data");
+		rc = EX_SOFTWARE;
+	}
+
+	m0_fini();
+
+	fclose(output_file);
+	fclose(input_file);
+
+	return rc;
+}
+
+/*
+ *  Local variables:
+ *  c-indentation-style: "K&R"
+ *  c-basic-offset: 8
+ *  tab-width: 8
+ *  fill-column: 80
+ *  scroll-step: 1
+ *  End:
+ */
+/*
+ * vim: tabstop=8 shiftwidth=8 noexpandtab textwidth=80 nowrap
+ */

--- a/experiments/m0trace/m0_log.c
+++ b/experiments/m0trace/m0_log.c
@@ -1,0 +1,57 @@
+#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_OTHER
+#include <stdio.h>
+#include <lib/time.h>
+#include "module/instance.h"      /* m0 */
+#include "mero/init.h"           /* m0_init */
+#include "lib/trace.h"
+#include "lib/user_space/trace.h" /* m0_trace_set_print_context */
+
+
+M0_INTERNAL int m0_time_init(void);
+M0_INTERNAL void m0_time_fini(void);
+
+int main(int argc, char **argv)
+{
+//    static struct m0 instance;
+//    int rc;
+
+/*  ***** Alternative Approach I *****
+    m0_instance_setup(&instance);
+    rc = m0_module_init(&instance.i_self, M0_LEVEL_INST_ONCE);
+    if (rc != 0)
+	    printf("m0_module_init failed\n");    
+*/
+
+/*  ***** Alternative Approach II *****
+    rc = m0_init(&instance);
+    if (rc != 0)
+            printf("Cannot initialise mero\n");
+*/
+
+    m0_time_init();
+
+    m0_trace_init();
+
+/*  ***** Alternative Approach I *****
+    m0_module_init(&instance.i_self, M0_LEVEL_INST_READY);
+*/
+    m0_trace_set_immediate_mask("all");
+    m0_trace_set_print_context("full");
+    m0_trace_set_level("DEBUG");
+
+    M0_LOG(M0_DEBUG, "Stand alone application for m0trace logging");
+
+    m0_trace_fini();
+
+    m0_time_fini();
+
+/*  ***** Alternative Approach II *****
+    m0_fini();
+*/
+
+/*  ***** Alternative Approach I *****
+    m0_module_fini(&instance.i_self, M0_MODLEV_NONE);
+*/
+
+    return 0;
+}


### PR DESCRIPTION
Used M0_LOG interface in the kvsns code base to log the messages in m0trace.<pid> file. Failed to see warning message for the trace descriptor related to my M0_LOG message.

We need improvement in the mero's m0_trace_parse method which is being tracked under EOS-3131. For now we are checking in this code base.

-bash-4.2$ sudo ./kvsns_init
local_addr = 10.230.166.38@tcp:12345:44:301
ha_addr    = 10.230.166.38@tcp:12345:45:1
profile    = <0x7000000000000001:0>
proc_fid   = <0x7200000000000000:0>
index_dir  = /tmp
kvs_fid    = <0x780000000000000b:1>
---------------------------
----------> tid=27129 I am the init thread
----------> tid=27129 I am the init thread
kvsns_start: kvsns init done for fs_id=0, rc=0, fs_ctx=0x7f0d0b8f2440
exec=kvsns_init -- ino=2, parent=2, path=/ prev=/
######## OK ########
-bash-4.2$ sudo m0tracedump -i m0trace.27129 -o m0trace.27129.dump
-bash-4.2$ vi m0trace.27129.dump

Not able to see the "kvsns init Successful" message in m0trace.27129.dump file.

-bash-4.2$ sudo ~/eos-fs/eos-fs/experiments/m0trace/kvsns_trace_dump -i m0trace.28643 -o m0trace.28643.dump
kvsns_trace_dump: Warning: skipping non-existing trace descriptor 0x7f0370db7da0 (orig 0x7ffff75b6da0)
kvsns_trace_dump: Warning: skipping non-existing trace descriptor 0x7f0370db7b20 (orig 0x7ffff75b6b20)
kvsns_trace_dump: Warning: skipping non-existing trace descriptor 0x7f0370db7960 (orig 0x7ffff75b6960)
kvsns_trace_dump: Warning: skipping non-existing trace descriptor 0x7f0370db7900 (orig 0x7ffff75b6900)
kvsns_trace_dump: Warning: skipping non-existing trace descriptor 0x7f0370db76c0 (orig 0x7ffff75b66c0)
kvsns_trace_dump: Warning: skipping non-existing trace descriptor 0x7f0370db7be0 (orig 0x7ffff75b6be0)
kvsns_trace_dump: Warning: skipping non-existing trace descriptor 0x7f03715da820 (orig 0x7ffff7dd9820)
kvsns_trace_dump: Warning: skipping non-existing trace descriptor 0x7f03715daa00 (orig 0x7ffff7dd9a00)
kvsns_trace_dump: Warning: skipping non-existing trace descriptor 0x7f03715daac0 (orig 0x7ffff7dd9ac0)

-bash-4.2$ ldd ~/eos-fs/eos-fs/experiments/m0trace/kvsns_trace_dump
        linux-vdso.so.1 =>  (0x00007ffcc77f4000)
        libkvsns.so => /lib64/libkvsns.so (0x00007f48171c0000)
        libmero.so.1 => /lib64/libmero.so.1 (0x00007f481686d000)
        libc.so.6 => /lib64/libc.so.6 (0x00007f48164a0000)
        libini_config.so.3 => /lib64/libini_config.so.3 (0x00007f4816286000)
        libextstore.so => /root/rpmbuild/BUILD/libkvsns-1.0.1-Source/extstore/mero/libextstore.so (0x00007f4816082000)
        libkvsal.so => /root/rpmbuild/BUILD/libkvsns-1.0.1-Source/kvsal/mero/libkvsal.so (0x00007f4815e7d000)
        libm0common.so => /root/rpmbuild/BUILD/libkvsns-1.0.1-Source/common/mero/libm0common.so (0x00007f4815c75000)
        libmero-helpers.so.0 => /lib64/libmero-helpers.so.0 (0x00007f4815a70000)
        libuuid.so.1 => /lib64/libuuid.so.1 (0x00007f481586b000)
        libyaml-0.so.2 => /lib64/libyaml-0.so.2 (0x00007f481564b000)
        libgf_complete.so.1 => /lib64/libgf_complete.so.1 (0x00007f4815425000)
        libm.so.6 => /lib64/libm.so.6 (0x00007f4815123000)
        libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f4814f07000)
        libaio.so.1 => /lib64/libaio.so.1 (0x00007f4814d05000)
        librt.so.1 => /lib64/librt.so.1 (0x00007f4814afd000)
        libdl.so.2 => /lib64/libdl.so.2 (0x00007f48148f9000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f48173cf000)
        libcollection.so.2 => /lib64/libcollection.so.2 (0x00007f48146ec000)
        libpath_utils.so.1 => /lib64/libpath_utils.so.1 (0x00007f48144e8000)
        libref_array.so.1 => /lib64/libref_array.so.1 (0x00007f48142e5000)
        libbasicobjects.so.0 => /lib64/libbasicobjects.so.0 (0x00007f48140e2000)
```