### PR TITLE
Use "2.8-stable-eos" branch for building NFS ganesha

### DIFF
--- a/scripts/build-nfs-ganesha.sh
+++ b/scripts/build-nfs-ganesha.sh
@@ -72,7 +72,7 @@ _nfs_ganesha_check_installed_pkgs() {
 ###############################################################################
 nfs_ganesha_bootstrap() {
     local rc=0
-    local stable_branch="V2.8-stable"
+    local stable_branch="2.8-stable-eos"
     local gan_deps=(
         bison
         cmake


### PR DESCRIPTION
Some of the NFS ganesha ACL apis/symbols are added to "ver" file
in order to export them. These symbols are used in kvsfs-ganesha
acl code. A new NFS ganesha branch - 2.8-stable-eos - has been
forked out for this. This patch makes sure that this branch will
be used for bootstrapping NFS ganesha.

Closes EOS-4905