### PR TITLE
EOS-10896: Fixed typo in nfs_setup(kvsfs-ganesha) for sanity test

### DIFF
--- a/kvsfs-ganesha/src/FSAL/FSAL_KVSFS/conf/nfs_setup.sh
+++ b/kvsfs-ganesha/src/FSAL/FSAL_KVSFS/conf/nfs_setup.sh
@@ -247,7 +247,7 @@ function usage {
 usage: $0 {init|cleanup} [-h] [-f] [-p] [-P <Profile>] [-F <Process FID>] [-k <KVS FID>] [-e <Local export>] [-E <HA export>]
 options:
   -h help
-  -f force initialisation
+  -f force initialization
   -p prompt
   -P Profile. Default is <0x7000000000000001:0>
   -F Process FID. Default is <0x7200000000000000:0>


### PR DESCRIPTION
[EOS-10896](https://jts.seagate.com/browse/EOS-10896) 
Fixed typo in nfs_setup script for sanity test after the kvsfs-ganesha submodule being merged into the cortx-posix repository.