### PR TITLE
EOS-11695: Fix the EFS UT regression from EOS-8650

### DIFF
--- a/efs/src/fs/fs.c
+++ b/efs/src/fs/fs.c
@@ -550,6 +550,6 @@ error:
 
 void efs_fs_close(struct efs_fs *efs_fs)
 {
-	kvtree_fini(efs_fs->kvtree);
-
+	// This is empty placeholder for future use
+	log_warn("Unused function is being called!");
 }


### PR DESCRIPTION
# EOS-11695:Fix the EFS UT regression from EOS-8650

## Problem Description
ut_efs_fs_teardown() was calling efs_fs_close() before calling efs_fs_delete(). efs_fs_close() internally calls kvtree_fini(), so later when efs_fs_delete(() tries to access kvtree of the root, it panics.

## Solution Overview
Nobody is using efs_fs_close() except ut_efs_fs_teardown(). So removed the kvtree_fini() from efs_fs_close() to fix this problem. This makes efs_fs_close() an empty stub, but it should be fine because all the work is being done from efs_fs_delete().


## Checklist

- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_


## Associated commit info from private branch EOS-11695
commit 1e6da3d5631ab5bfb49b5978bc237c7111be3e37
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Tue Aug 4 23:20:23 2020 -0600

    EOS-11695: Fix the EFS UT regression from EOS-8650
    Branch: EOS-11695

    List of added/modified/deleted files:
        modified:   efs/src/fs/fs.c

    Root cause analysis:
        ut_efs_fs_teardown() was calling efs_fs_close() before calling efs_fs_delete().
        efs_fs_close() internally calls kvtree_fini(), so later when efs_fs_delete(()
        tries to access kvtree of the root, it panics.

    Code change description:
        Nobody is using efs_fs_close() except ut_efs_fs_teardown(). So removed the kvtree_fini()
        from efs_fs_close() to fix this problem. This makes efs_fs_close() an empty stub, but it
        should be fine because all the work is being done from efs_fs_delete().

    Unit test (on LABVM):
        Without this change, the reported issue is easily reproducible, but with
        this fix, the panic is fixed and efs UT tests are passing.
        With this change, compilation works and basic NFS operations work fine on NFS mounts.
        UT tests o/p after this fix:
        751521@ssc-vm-c-0040: cortx-posix:$sudo ./scripts/test.sh
        [sudo] password for 751521:
         --
        NSAL Unit tests
        NS Tests
        Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
        Total tests  = 5
        Tests passed = 5
        Tests failed = 0

        Iterator test
        Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
        Total tests  = 2
        Tests passed = 2
        Tests failed = 0

        KVTree test
        Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
        Total tests  = 17
        Tests passed = 17
        Tests failed = 0

        EFS Unit tests
        Endpoint ops Tests
        Test results are logged to /var/log/cortx/test/ut/ut_efs.logs
        Total tests  = 4
        Tests passed = 4
        Tests failed = 0

        FS Tests
        Test results are logged to /var/log/cortx/test/ut/ut_efs.log
        Total tests  = 3
        Tests passed = 3
        Tests failed = 0

        Directory tests
        Test results are logged to /var/log/cortx/test/ut/ut_efs.log
        Total tests  = 12
        Tests passed = 12
        Tests failed = 0

        File creation tests
        Test results are logged to /var/log/cortx/test/ut/ut_efs.log
        Total tests  = 3
        Tests passed = 3
        Tests failed = 0

        Link Tests
        Test results are logged to /var/log/cortx/test/ut/ut_efs.log
        Total tests  = 6
        Tests passed = 6
        Tests failed = 0

        Rename tests
        Test results are logged to /var/log/cortx/test/ut/ut_efs.log
        Total tests  = 3
        Tests passed = 3
        Tests failed = 0

        Attribute Tests
        Test results are logged to /var/log/cortx/test/ut/ut_efs.log
        Total tests  = 5
        Tests passed = 5
        Tests failed = 0

        Xattr file Tests
        Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
        Total tests  = 9
        Tests passed = 9
        Tests failed = 0

        Xattr dir Tests
        Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
        Total tests  = 9
        Tests passed = 9
        Tests failed = 0

        IO tests
        Test results are logged to /var/log/cortx/test/ut/ut_efs.log
        Total tests  = 6
        Tests passed = 6
        Tests failed = 0
