### PR TITLE
EOS-10521: nfstest_posix fails for access.

### DIFF
--- a/efs/src/efs/efs_xattr.c
+++ b/efs/src/efs/efs_xattr.c
@@ -85,9 +85,6 @@ size_t efs_getxattr(struct efs_fs *efs_fs, efs_cred_t *cred,
 	dassert(size != NULL);
 	dassert(*size != 0);
 
-	RC_WRAP_LABEL(rc, out, efs_access, efs_fs, cred, ino,
-		      EFS_ACCESS_READ);
-
 	RC_WRAP_LABEL(rc, out, efs_ino_to_oid, efs_fs, ino, &oid);
 
 	RC_WRAP_LABEL(rc, out, md_xattr_get, &(efs_fs->kvtree->index), (obj_id_t *)&oid, name,


### PR DESCRIPTION
Problem Statement :
EOS-10521: nfstest_posix fails for access.
Problem Description:
nfstest_posix, access test is failing for permissions 0333, 0222, 0111,
0000 for non root user.
We are not able to fetch the acls because efs_getxattr() checks for read
access before fetching acls. Users with permissions 0333, 0222, 0111,
0000 fails this read access check and acls are not fetched.
kvsfs_getattrs() fails with EPERM.
Solution Overview:
I have checked that in Linux user need not to have any permissions to
fetch the attributes. efs_getattr() also does not check for any
permissions. Thus removing the read access check from efs_getxattr() as well.
Unit Test Cases:
nfstest_posix access test passed for non root user.
EFS UT passed.
Cthon basic tests passed.

Signed-off-by: Shipra <shipra.gupta@seagate.com>