### PR TITLE
EOS-10573: Fix for multiple export mount failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ TAGS
 *libfsalkvsfs.spec
 build-kvsns
 build-kvsfs
+*.spec
+*.pc

--- a/kvsfs-ganesha/src/FSAL/FSAL_KVSFS/main.c
+++ b/kvsfs-ganesha/src/FSAL/FSAL_KVSFS/main.c
@@ -37,9 +37,11 @@
 /* TODO:ATTR4_SEC_LABEL are not supported yet. */
 #define KVSFS_SUPPORTED_ATTRIBUTES ((const attrmask_t) (ATTRS_POSIX | ATTR_ACL ))
 
-#define KVSFS_LINK_MAX EFS_MAX_LINK
+#define KVSFS_LINK_MAX         EFS_MAX_LINK
+#define FSAL_NAME              "CORTX-FS"
+#define DBUS_INTERFACE_NAME    "org.ganesha.nfsd.config.fsal.cortxfs"
 
-const char module_name[] = "KVSFS";
+const char module_name[] = FSAL_NAME;
 
 /* default parameters for EFS filesystem */
 static const struct fsal_staticfsinfo_t default_kvsfs_info = {
@@ -110,8 +112,8 @@ static struct config_item kvsfs_params[] = {
 };
 
 struct config_block kvsfs_param = {
-	.dbus_interface_name = "org.ganesha.nfsd.config.fsal.kvsfs",
-	.blk_desc.name = "KVSFS",
+	.dbus_interface_name = DBUS_INTERFACE_NAME,
+	.blk_desc.name = FSAL_NAME,
 	.blk_desc.type = CONFIG_BLOCK,
 	.blk_desc.u.blk.init = noop_conf_init,
 	.blk_desc.u.blk.params = kvsfs_params,


### PR DESCRIPTION
# EFS Change Summary
## Problem Statement
[EOS-10573](https://jts.seagate.com/browse/EOS-10573) Multiple FS Mount

## Problem Description
When two or more fs are created and exported, only the first EXPORT is able to mount.
Behavior seen: On the deletion of the first EXPORT, the second EXPORT is able to mount.

Detailed analysis of the bug, logged errors as **Errors processing block (FSAL).**
The problem with load_fsal:NFS STARTUP :CRIT :Could not execute symbol fsal_init from module:/usr/lib64/ganesha//libfsalcortx-fs.so  was:
it was unable to find the run-time address in the shared object handle.
load_fsal() -> calls register_fsal() and takes the module name as KVSFS instead of CORTX-FS as defined in ganesha.conf.

## Solution Overview
### Observed

**Export-1 :** 

- lookup_fsal(FSAL name- CORTX-FS) ---fails
- register_fsal(KVSFS)
- load_fsal()
- set reference count -1

**Export-2 :**

- lookup_fsal(FSAL name- CORTX-FS) ---fails as registered fsal name is KVSFS.
- load_fsal()  ---fails and results config errors in FSAL block.**

### Expected

**Export-1 :** 
- lookup_fsal(FSAL name- CORTX-FS) ---fails as first export
- register_fsal(CORTX-FS)
- load_fsal()
- set reference count -1

**Export-2 :**
- lookup_fsal(FSAL name- CORTX-FS) ---success
- increments ref_count to 2

## Unit Test Cases
 Able to mount all exports using at the nfs-client side.

# MR checklist
- [x] Compilation: This patch does not break compilation

- [x] Documentation: This patch and the merge request have up-to-date descriptions.

- [x] Dependencies:  This is an independent patch.

- [x] Merge conflicts: This patch has been squashed and re-based, it can be merged using a fast-forward merge.

- [x] Code review: All discussions have been addressed.