### PR TITLE
EOS-11801: CORTX-NFS : Fix build dependencies for rename of Mero to Motr

### DIFF
--- a/dsal/src/CMakeLists.txt
+++ b/dsal/src/CMakeLists.txt
@@ -56,8 +56,8 @@ if (USE_POSIX_OBJ OR USE_EOS_STORE)
 endif(USE_POSIX_OBJ OR USE_EOS_STORE)
 
 if (USE_EOS_STORE)
-  set(RPM_REQUIRES "mero ${RPM_REQUIRES}")
-  set(RPM_DEVEL_REQUIRES "mero-devel ${RPM_DEVEL_REQUIRES}")
+  set(RPM_REQUIRES "motr ${RPM_REQUIRES}")
+  set(RPM_DEVEL_REQUIRES "motr-devel ${RPM_DEVEL_REQUIRES}")
 endif (USE_EOS_STORE)
 
 if (USE_EOS_STORE)
@@ -102,7 +102,7 @@ if(USE_EOS_STORE)
 	""
 	HAVE_EOS
 	)
-  check_include_files("mero/config.h" HAVE_EOS_H)
+  check_include_files("motr/config.h" HAVE_EOS_H)
 
   find_library(HAVE_EOS_HELPERS motr-helpers)
   check_library_exists(

--- a/dsal/src/dstore/plugins/eos/CMakeLists.txt
+++ b/dsal/src/dstore/plugins/eos/CMakeLists.txt
@@ -2,9 +2,9 @@ set(EOS_CFLAGS "-D_REENTRANT -D_GNU_SOURCE -DM0_INTERNAL='' -DM0_EXTERN=extern "
 set(EOS_CFLAGS "${EOS_CFLAGS} -include config.h ")
 set(EOS_CFLAGS "${EOS_CFLAGS} -Wall -Werror -Wno-attributes -Wno-unused-but-set-variable ")
 set(EOS_CFLAGS "${EOS_CFLAGS} -fno-strict-aliasing -fno-omit-frame-pointer  -fno-common -fPIC ")
-set(EOS_CFLAGS "${EOS_CFLAGS} -I/usr/include/mero -I/usr/include/libcfs ")
+set(EOS_CFLAGS "${EOS_CFLAGS} -I/usr/include/motr -I/usr/include/libcfs ")
 
-include_directories("/usr/include/mero")
+include_directories("/usr/include/motr")
 include_directories(${EOSUTILSINC})
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EOS_CFLAGS}")

--- a/efs/src/efs/CMakeLists.txt
+++ b/efs/src/efs/CMakeLists.txt
@@ -2,9 +2,9 @@ set(EOS_CFLAGS "-D_REENTRANT -D_GNU_SOURCE -DM0_INTERNAL='' -DM0_EXTERN=extern "
 set(EOS_CFLAGS "${EOS_CFLAGS} -include config.h ")
 set(EOS_CFLAGS "${EOS_CFLAGS} -Wall -Werror -Wno-attributes -Wno-unused-but-set-variable ")
 set(EOS_CFLAGS "${EOS_CFLAGS} -fno-strict-aliasing -fno-omit-frame-pointer  -fno-common -fPIC ")
-set(EOS_CFLAGS "${EOS_CFLAGS} -I/usr/include/mero -I/usr/include/libcfs ")
+set(EOS_CFLAGS "${EOS_CFLAGS} -I/usr/include/motr -I/usr/include/libcfs ")
 
-include_directories("/usr/include/mero")
+include_directories("/usr/include/motr")
 include_directories(${EOSUTILSINC})
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EOS_CFLAGS}")

--- a/nsal/src/CMakeLists.txt
+++ b/nsal/src/CMakeLists.txt
@@ -60,8 +60,8 @@ else (USE_KVS_EOS)
 endif (USE_KVS_EOS)
 
 if (USE_KVS_EOS OR USE_MERO_STORE)
-  set(RPM_REQUIRES "mero ${RPM_REQUIRES}")
-  set(RPM_DEVEL_REQUIRES "mero-devel ${RPM_DEVEL_REQUIRES}")
+  set(RPM_REQUIRES "motr ${RPM_REQUIRES}")
+  set(RPM_DEVEL_REQUIRES "motr-devel ${RPM_DEVEL_REQUIRES}")
 endif (USE_KVS_EOS OR USE_MERO_STORE)
 
 if (USE_KVS_REDIS)
@@ -149,7 +149,7 @@ if(USE_KVS_EOS OR USE_MERO_STORE)
 	""
 	HAVE_MERO
 	)
-  check_include_files("mero/config.h" HAVE_MERO_H)
+  check_include_files("motr/config.h" HAVE_MERO_H)
 
   find_library(HAVE_MERO_HELPERS motr-helpers)
   check_library_exists(

--- a/nsal/src/common/mero/CMakeLists.txt
+++ b/nsal/src/common/mero/CMakeLists.txt
@@ -3,11 +3,11 @@ set(MERO_CFLAGS "-D_REENTRANT -D_GNU_SOURCE -DM0_INTERNAL='' -DM0_EXTERN=extern 
 set(MERO_CFLAGS "${MERO_CFLAGS} -include config.h ")
 set(MERO_CFLAGS "${MERO_CFLAGS} -Wall -Werror -Wno-attributes -Wno-unused-but-set-variable ") 
 set(MERO_CFLAGS "${MERO_CFLAGS} -fno-strict-aliasing -fno-omit-frame-pointer  -fno-common -fPIC ") 
-set(MERO_CFLAGS "${MERO_CFLAGS} -I/usr/include/mero -I/usr/include/libcfs ")
+set(MERO_CFLAGS "${MERO_CFLAGS} -I/usr/include/motr -I/usr/include/libcfs ")
 set(MERO_CFLAGS "${MERO_CFLAGS} -I/usr/include/lustre")
 
 include_directories("/usr/include/mero")
-#LIBS=-lm -lpthread -lrt -lgf_complete -lyaml -luuid -lmero 
+#LIBS=-lm -lpthread -lrt -lgf_complete -lyaml -luuid -lmotr
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${MERO_CFLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MERO_CFLAGS}")

--- a/nsal/src/common/mero/m0common.c
+++ b/nsal/src/common/mero/m0common.c
@@ -34,7 +34,7 @@
 #include "clovis/clovis_idx.h"
 #include "lib/thread.h"
 #include "m0common.h"
-#include <mero/helpers/helpers.h>
+#include <motr/helpers/helpers.h>
 
 /* Key Iterator */
 

--- a/nsal/src/kvstore/plugins/eos/CMakeLists.txt
+++ b/nsal/src/kvstore/plugins/eos/CMakeLists.txt
@@ -2,7 +2,7 @@ set(EOS_CFLAGS "-D_REENTRANT -D_GNU_SOURCE -DM0_INTERNAL='' -DM0_EXTERN=extern "
 set(EOS_CFLAGS "${EOS_CFLAGS} -include config.h ")
 set(EOS_CFLAGS "${EOS_CFLAGS} -Wall -Werror -Wno-attributes -Wno-unused-but-set-variable ")
 set(EOS_CFLAGS "${EOS_CFLAGS} -fno-strict-aliasing -fno-omit-frame-pointer  -fno-common -fPIC ")
-set(EOS_CFLAGS "${EOS_CFLAGS} -I/usr/include/mero -I/usr/include/libcfs ")
+set(EOS_CFLAGS "${EOS_CFLAGS} -I/usr/include/motr -I/usr/include/libcfs ")
 set(EOS_CFLAGS "${EOS_CFLAGS} -I/usr/include/lustre")
 
 include_directories("/usr/include/mero")

--- a/nsal/src/metadata/CMakeLists.txt
+++ b/nsal/src/metadata/CMakeLists.txt
@@ -2,7 +2,7 @@ set(MERO_CFLAGS "-D_REENTRANT -D_GNU_SOURCE -DM0_INTERNAL='' -DM0_EXTERN=extern 
 set(MERO_CFLAGS "${MERO_CFLAGS} -include config.h ")
 set(MERO_CFLAGS "${MERO_CFLAGS} -Wall -Werror -Wno-attributes -Wno-unused-but-set-variable ")
 set(MERO_CFLAGS "${MERO_CFLAGS} -fno-strict-aliasing -fno-omit-frame-pointer  -fno-common -fPIC ")
-set(MERO_CFLAGS "${MERO_CFLAGS} -I/usr/include/mero -I/usr/include/libcfs ")
+set(MERO_CFLAGS "${MERO_CFLAGS} -I/usr/include/motr -I/usr/include/libcfs ")
 set(MERO_CFLAGS "${MERO_CFLAGS} -I/usr/include/lustre")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${MERO_CFLAGS}")

--- a/utils/src/eos/CMakeLists.txt
+++ b/utils/src/eos/CMakeLists.txt
@@ -5,7 +5,7 @@ set(EOS_CFLAGS "${EOS_CFLAGS} -fno-strict-aliasing -fno-omit-frame-pointer  -fno
 set(EOS_CFLAGS "${EOS_CFLAGS} -I/usr/include/mero -I/usr/include/libcfs ")
 #set(EOS_CFLAGS "${EOS_CFLAGS} -I/usr/include/lustre")
 
-include_directories("/usr/include/mero")
+include_directories("/usr/include/motr")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EOS_CFLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EOS_CFLAGS}")

--- a/utils/src/eos/m0common.c
+++ b/utils/src/eos/m0common.c
@@ -80,7 +80,7 @@ int m0init(struct collection_item *cfg_items)
 
 		memset(&m0thread, 0, sizeof(struct m0_thread));
 
-		m0_thread_adopt(&m0thread, clovis_instance->m0c_mero);
+		m0_thread_adopt(&m0thread, clovis_instance->m0c_motr);
 	} else
 		log_info("----------> tid=%d I am the init thread\n",
 		       (int)syscall(SYS_gettid));

--- a/utils/src/eos/m0common.h
+++ b/utils/src/eos/m0common.h
@@ -36,7 +36,7 @@
 #include "clovis/clovis_idx.h"
 #include "lib/thread.h"
 #include <eos/helpers.h>
-#include <mero/helpers/helpers.h>
+#include <motr/helpers/helpers.h>
 
 struct clovis_io_ctx {
 	struct m0_indexvec ext;


### PR DESCRIPTION
### Overview ### 
 CORTX-NFS : Fix build dependencies for rename of Mero to Motr
https://jts.seagate.com/browse/EOS-11801

### Description ###
For the open sourcing initiatives, it's a requirement to rename Mero to Motr and Clovis to libmotr. 
For now, the Motr team has replaced all the instances of mero to motr in motr(formerly mero) source code. The name changes of Motr to Clovis will be done later
The changes from Mero-to-Motr have been done in a private branch "cortx-rename-work-new". 
These changes will affect the cortx-nfs rpms since there are dependencies on mero. 

### Fix ###
Fix all the build and runtime dependencies in NFS due to renaming of mero-to-motr. 

### Tests ###

- NFS build pass with the motr rpms created from "cortx-rename-work-new"
- NFS RPMS are be built successfully.
- NFS RPMS are  installed successfully
- All UTS pass
- CTHON basic tests pass
- NFS Operations work from NFS client.