### PR TITLE
EOS-8822: Add interfaces for integration with ADDB.

### DIFF
--- a/utils/src/CMakeLists.txt
+++ b/utils/src/CMakeLists.txt
@@ -45,8 +45,15 @@ endif (ENABLE_DASSERT)
 
 message( STATUS "ENABLE_DASSERT : ${ENABLE_DASSERT}")
 
+# TODO: Add a configure-time option
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DENABLE_TSDB_ADDB")
+
 include(CheckIncludeFiles)
 include(CheckLibraryExists)
+
+# Add TSDB sources
+add_subdirectory(tsdb)
+set(UTILS_TSDB utils-tsdb)
 
 # Build ancillary libs
 add_subdirectory(fault)
@@ -87,6 +94,7 @@ set(CMAKE_EV_LIB /usr/local/lib)
 link_directories(${CMAKE_EV_LIB})
 
 add_library(${UTILS_LIB} SHARED
+		$<TARGET_OBJECTS:${UTILS_TSDB}>
 		$<TARGET_OBJECTS:${UTILS_FAULT}>
 		$<TARGET_OBJECTS:${UTILS_LOG}>
 		$<TARGET_OBJECTS:${UTILS_EOS}>

--- a/utils/src/include/operation.h
+++ b/utils/src/include/operation.h
@@ -1,0 +1,355 @@
+/**
+ * Filename:	operation.h
+ * Description:	This module defines Operation API.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.*
+ */
+#ifndef OPERATION_H_
+#define OPERATION_H_
+/******************************************************************************/
+#include <stdint.h> /* uintX_t */
+#include <inttypes.h> /* PRIxY */
+#include "perf/perf-counters.h" /* import all perf counters definitions */
+
+/* Operation API overview
+ * ----------------------
+ *
+ * Operation API provides its users with an ability to establish
+ * manual tracing of function calls.
+ * There are a plenty of existing tools and libraries that
+ * provide similar functionality for automatic tracing
+ * (valgrind callgraph tool, linux perf etc.) and manual tracing
+ * (various trace-point libraries).
+ *
+ * Operation API has the notion of opcall (or just call) that
+ * describes one particular call to a function. These calls can be grouped
+ * together into opstack.
+ *
+ * Since we want to be able to identify the function that was called
+ * within an opcall, we need an ID for that function.
+ * This ID has to be a value that is constant, and does not depend
+ * on linking or compiling processes (otherwise, we could use the trick with
+ * a reference variable). Because of that this ID has to be defined
+ * in the source code, and it has to be unique.
+ * That's where we introduce operation tags. They help us to identify functions,
+ * and the modctx.mod_id designators help us to keep operation tags unique
+ * only within one single module.
+ *
+ * opcall.fn_id is the field where an operation tag is stored.
+ * The field is not called "optag" just for the sake of clarity of the scope:
+ *	op.mod - Module
+ *	op.fn_id - Function in the module
+ *	op.call_id - One of the calls to the function.
+ * So basically, fn_id is an alias for operation tag.
+ *
+ * Operation tag and module creates the (fn_id, mod_id) tuple. This tuple
+ * is called "action" or "action ID" in TSDB. An action is unique across
+ * the whole system.
+ * The relation between fn_id, mod_id and action can be described in
+ * the following way:
+ *
+ * @{code}
+ *	// A global enum that can be used by any module defined in the list.
+ *	enum ::m { MOD_A, MOD_B, MOD_C, ... }
+ *	// Operation tags for the module MOD_A (and defined there).
+ *	enum mod_a::optags { OP_1, OP_2, ... };
+ *	// Operation tags for the module MOD_B (and defined there).
+ *	enum mod_b::optags { OP_1, OP_2, ... };
+ *
+ *	constant ::MOD_OFFSET;
+ *
+ *	mod_a {
+ *		import ::m;
+ *		op_1() {
+ *			action = (::m::MOD_A << ::MOD_OFFSET) | mod_a::OP_1;
+ *		}
+ *		...
+ *	}
+ *	mod_b {
+ *		import ::m;
+ *		op_1() {
+ *			action = (::m::MOD_B << ::MOD_OFFSET) | mod_b::OP_1;
+ *		}
+ *	}
+ * @{endcode}
+ *
+ */
+
+/******************************************************************************/
+/* Public data types */
+
+/** Per-module context that helps to maintain per-module operation tags.
+ * See the overview for the details about relations between modules
+ * and operation tags.
+ */
+struct modctx {
+	/** Generates unique IDs for each call within the module. */
+	uint64_t op_counter;
+	/** Unique (across the system) ID for the module. */
+	uint64_t mod_id;
+};
+
+/** Module context initializer. */
+#define MODCTX_INIT(__mod_id) (struct modctx) { \
+	.op_counter = 0,			\
+	.mod_id = __mod_id,			\
+}
+
+/** The structure defines one single call in a callstack */
+struct opcall {
+	/** Unique identifier (generated) of the call. */
+	uint64_t call_id;
+	/** Unique identifier (hardcoded) of the function
+	 * that was used within the call.
+	 */
+	uint64_t fn_id;
+	/** Reference to the module where the function
+	 * was called.
+	 */
+	const struct modctx *mod;
+	/** Function name of the point where "opcall" was created.
+	 * It is not required for tracing events (fn_id is used
+	 * instead); however, it is required for debugging.
+	 */
+	const char *fn_name;
+};
+
+/** Format string for debugging representation of "opcall" */
+#define OPCALL_DBG_FMT "c=%" PRIu64 ", f=%" PRIu64 ", m=%" PRIu64 ", n='%s'"
+
+/** Format arguments for OPCALL_DBG_FMT. */
+#define OPCALL_DBG_P(_opc)	\
+	(_opc)->call_id,	\
+	(_opc)->fn_id,		\
+	(_opc)->mod->mod_id,	\
+	(_opc)->fn_name
+
+
+enum {
+	/** The maximum count of elements in a stack
+	 * of operation calls.
+	 * At this moment, 8 is a relatively safe value, so
+	 * we double it, and use it here.
+	 * NOTE: The size and the whole structure may be a subject
+	 * to performance optimizations when we encounter
+	 * such a need. But right now we just maintain a safe boundary.
+	 */
+	MAX_OPSTACK_DEPTH = 16,
+};
+_Static_assert(MAX_OPSTACK_DEPTH > 0, "opstack cannot be empty");
+
+/** An object that keeps the information about stack of calls.
+ * It is an "Ariadne's thread" between the place where operation
+ * was originated (described by "head", i.e. ctxstack[0] value)
+ * and any location to which the opstack was propogated.
+ */
+struct opstack {
+	/** Call stack information. */
+	struct opcall ctxstack[MAX_OPSTACK_DEPTH];
+	/** The current stack size. */
+	uint64_t depth;
+};
+
+/******************************************************************************/
+/* Private intefaces: opcall and opstack helpers */
+
+/** Initializes a new instance of a call to a function (or operation)
+ * within a module.
+ * Note:
+ *  This macro uses a builtin function to ensure atomicity of the counter.
+ *  Since the compiler and processor are able to re-order operations and
+ *  access to memory, we have to use a primitive that helps to perform
+ *  atomic increment. At this moment we are using gcc-4.8, and C11 is not
+ *  specified as the standard, so we have to use the "old" __sync builtins.
+ *  Once the gcc version and/or the standard version are upgraded, we can
+ *  switch to the __atomic builtins or the atomic_ data types.
+ */
+#define OPCALL_INIT(__mod, __tag) (struct opcall) {			\
+	.call_id = __sync_add_and_fetch(&(__mod)->op_counter, 1),	\
+	.mod = (__mod),							\
+	.fn_id = (__tag),						\
+	.fn_name = __FUNCTION__,					\
+}
+
+#define OPCALL_INIT_EMPTY() (struct opcall) {	\
+	.call_id = 0,				\
+}
+
+/** Get the origin of an operation. */
+static inline struct opcall *opstack_head(struct opstack *opstack)
+{
+	return &opstack->ctxstack[0];
+}
+
+/** Get the current context of an operation. */
+static inline struct opcall *opstack_curr(struct opstack *opstack)
+{
+	return &opstack->ctxstack[opstack->depth - 1];
+}
+
+/** Get the caller of the current operation. */
+static inline struct opcall *opstack_caller(struct opstack *opstack)
+{
+	return &opstack->ctxstack[opstack->depth - 2];
+}
+
+/** Initializes an opstack structure with the very first value (origin). */
+#define OPSTACK_INIT(__mod, __tag) (struct opstack) {		\
+	.ctxstack[0] = OPCALL_INIT(__mod, __tag),		\
+	.depth = 1,						\
+}
+
+/** Initializes an opstack structure with no data.
+ * Any opstack created by this call is considered invalid until
+ * OPSTACK_INIT is called to populate it again. It is because the following
+ * invariant should be held for a valid opstack:
+ *	opstack.depth > 0
+ * It means a valid opstack always has the origin (head).
+ * This macro can be used to "finalize" an opstack structure.
+ */
+#define OPSTACK_INIT_EMPTY() (struct opstack) {			\
+	.ctxstack[0] = OPCALL_INIT_EMPTY(),			\
+	.depth = 0,						\
+}
+
+/******************************************************************************/
+/* Public interface: op and ctx mgmt. */
+
+/** Origin of an operation.
+ * This macro should be put at the location where we want to start
+ * tracking an operation.
+ * Example:
+ * @{code}
+ *	struct opstack;
+ *	opstack_begin(&opstack, &g_my_mod, MY_TAG, some_arg);
+ *	other_args = arg_to_other_arg(some_arg);
+ *	rc = do_smth(&opstack, other_args);
+ *	opstack_end(&opstack, rc);
+ *	return rc;
+ * @{endcode}
+ *
+ * @param _op Uninitialized opstack object.
+ * @param _mod Pointer to the module context.
+ * @param _tag ID of function/operation.
+ * @param __VA_ARGS__ Any uint64_t values.
+ */
+#define opstack_begin(_op, _mod, _tag, ...) do {			\
+	*(_op) = OPSTACK_INIT(_mod, _tag);				\
+	PERFC_OP_EE(							\
+		opstack_curr(_op)->mod->mod_id,				\
+		opstack_curr(_op)->fn_id,				\
+		opstack_curr(_op)->call_id,				\
+		PERFC_EE_OP_BEGIN,					\
+		__VA_ARGS__						\
+	);								\
+} while(0)
+
+/** Defines the point where an operation ends.
+ * @param _op Initialized opstack object.
+ * @param __VA_ARGS__ Any uint64_t values.
+ */
+#define opstack_end(_op, ...) do { \
+	PERFC_OP_EE(							\
+		opstack_curr(_op)->mod->mod_id,				\
+		opstack_curr(_op)->fn_id,				\
+		opstack_curr(_op)->call_id,				\
+		PERFC_EE_OP_END,					\
+		__VA_ARGS__						\
+	);								\
+	*(_op) = OPSTACK_INIT_EMPTY();					\
+} while(0)
+
+/** Defines the point where an operation ends (as an expression).
+ * The same as opstack_end but expression. Example of usage:
+ * {code}
+ *	opstack op;
+ *	opstack_begin(&op, &m, MY_TAG);
+ *	// ...
+ * out:
+ *	return opstack_end_rc(&op, rc);
+ * {endcode}
+ */
+#define opstack_end_rc(_op, __rc, ...) ({				\
+	PERFC_OP_EE(							\
+		opstack_curr(_op)->mod->mod_id,				\
+		opstack_curr(_op)->fn_id,				\
+		opstack_curr(_op)->call_id,				\
+		PERFC_EE_OP_END,					\
+		__rc,							\
+		__VA_ARGS__						\
+	);								\
+	*(_op) = OPSTACK_INIT_EMPTY();					\
+	__rc;								\
+})
+
+/** Change the context. */
+#define opstack_push(__op, __mod, __tag) do {		\
+	if ((__op)->depth < MAX_OPSTACK_DEPTH) {	\
+		(__op)->ctxstack[(__op)->depth++] =	\
+			OPCALL_INIT(__mod, __tag);	\
+	}						\
+} while (0)
+
+/** Restore the context. */
+#define opstack_pop(__op) do {				\
+	if ((__op)->depth > 0) {			\
+	(__op)->ctxstack[(__op)->depth--] =		\
+		OPCALL_INIT_EMPTY();			\
+	}						\
+} while (0)
+
+/** Mark the point of connection between an operation
+ * and an external operation.
+ */
+#define opstack_map_head2external(__op, __map_tag, __key, ...) do {	\
+	PERFC_MAP(opstack_head(__op)->mod->mod_id,			\
+		  opstack_head(__op)->fn_id,				\
+		  opstack_head(__op)->call_id,				\
+		  __map_tag, __key, __VA_ARGS__);			\
+} while (0);
+
+/******************************************************************************/
+/* Public interface: hardcoded list of modules. */
+
+/** A hardcoded list of modules to be used within operation tags.
+ * The list is hardcoded due to the following reasons:
+ *	- Decoding of records should be independent from ordering
+ *	of loaded modules. Otherwise, we could use reference variables or
+ *	something similar. However, it has been proven that such approach
+ *	leads to significant troubles during decoding stage.
+ *	- There has to be no collisions in the list. Again, there may be
+ *	a lot of ways to ensure there are no collisions, but this is
+ *	the simplest one.
+ */
+enum tsdb_modules {
+	/* A list of well-known modules */
+	TSDB_MOD_UTILS = 0,
+	TSDB_MOD_DSAL,
+	TSDB_MOD_NSAL,
+	TSDB_MOD_FS,
+	TSDB_MOD_FSUSER,
+	TSDB_MOD_UT,
+	TSDB_MOD_LAST = TSDB_MOD_UT,
+
+	/* Custom module ids. Note: this range
+	 * of ids is not protected from collisions
+	 */
+	TSDB_MOD_CUSTOM_START = TSDB_MOD_LAST + 1,
+	TSDB_MOD_CUSTOM_END = TSDB_MOD_LAST + 16,
+};
+
+
+/******************************************************************************/
+#endif /* OPERATION_H_ */

--- a/utils/src/include/perf/perf-counters.h
+++ b/utils/src/include/perf/perf-counters.h
@@ -1,0 +1,115 @@
+/**
+ * Filename:	perf-counters.h
+ * Description:	This module defines performance counters and helpers.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.*
+ */
+#ifndef PERF_COUNTERS_H_
+#define PERF_COUNTERS_H_
+/******************************************************************************/
+#include "perf/tsdb.h" /* ACTION_ID_BASE */
+
+/******************************************************************************/
+/** Subtags for entry/exit points and mappings. */
+enum perfc_subtags {
+	PERFC_EE_OP_BEGIN = 0xB,
+	PERFC_EE_OP_END = 0xE,
+	PERFC_EE_OP_PUSH = 0x1,
+	PERFC_EE_OP_POP = 0x2,
+	PERFC_MAP = 0xF,
+};
+
+/** Creates a unique id for a function (or any other "action"). */
+#define TSDB_MK_AID(__mod_id, __tag) \
+	(TSDB_ACTION_ID_BASE + ((__mod_id) << 12 | (__tag)))
+
+/* Format of Entry/Exit points:
+ * | <AID> | <EE type> | <Call ID> | [Rest] |
+ * where
+ *	- AID - action id (function id)
+ *	- EE type - begin/end/push/pop
+ *	- Call ID - id the particular call
+ *	- Rest - operation-specific arguments.
+ *
+ * Arguments:
+ *	__mod - Module ID (hardcoded).
+ *	__fn  - Function ID (hardcoded).
+ *	__call - Call ID (generated).
+ *	__VA_ARGS_ - Optional arguments.
+ */
+#define PERFC_OP_EE(__mod, __fn, __call, __ee_type, ...)			\
+	TSDB_ADD(TSDB_MK_AID(__mod, __fn), __ee_type , __call,	\
+		 __VA_ARGS__)
+
+
+/* Format of mappings :
+ * | <AID> | MAP | <Call ID> | <MAP-ID> | <EXTERNAL-ID> |
+ * where
+ *	AID - action id (function id)
+ *	MAP - constant (PERFC_MAP)
+ *	MAP-ID - id of the mapping.
+ *	Call ID - id the particular call to AID
+ *	EXTERNAL-ID - id of the foreign operation (M0, XID, etc).
+ * This structure forms the following mapping:
+ *	<MAP-ID> : KEY -> EXTERNAL-ID
+ *	where KEY is a combination of function id and call id.
+ */
+
+#define PERFC_MAP(__mod_id, __fn, __call, __map_id, __ext_id, ...) \
+	TSDB_ADD(TSDB_MK_AID(__mod_id, __fn), PERFC_MAP,  __call, \
+		 __map_id, __ext_id, __VA_ARGS__)
+
+
+/* TODO: move it into submodules */
+
+enum perfc_efs {
+	PERFC_EFS_MKDIR,
+};
+
+enum perfc_nsal {
+	PERFC_NSAL_GET,
+	PERFC_NSAL_SET,
+	PERFC_NSAL_LISTCB,
+	PERFC_NSAL_DEL,
+};
+
+enum perfc_m0_adapter {
+	/* EE points */
+	PERFC_M0A_GET,
+	PERFC_M0A_PUT,
+	PERFC_M0A_NEXT,
+	PERFC_M0A_DEL,
+
+	PERFC_M0A_OBJ_CREATE,
+	PERFC_M0A_OBJ_DELETE,
+	PERFC_M0A_OBJ_OPEN,
+	PERFC_M0A_OBJ_CLOSE,
+
+	PERFC_M0A_IDX_CREATE,
+	PERFC_M0A_IDX_DELETE,
+	PERFC_M0A_IDX_OPEN,
+	PERFC_M0A_IDX_CLOSE,
+
+	/* Mappings */
+	PERFC_M0A_MAP_GET,
+	PERFC_M0A_MAP_PUT,
+	PERFC_M0A_MAP_NEXT,
+	PERFC_M0A_MAP_DEL,
+};
+
+
+
+/******************************************************************************/
+#endif /* PERF_COUNTERS_H_ */

--- a/utils/src/include/perf/tsdb-addb.h
+++ b/utils/src/include/perf/tsdb-addb.h
@@ -1,0 +1,50 @@
+/**
+ * Filename:	tsdb-addb.h
+ * Description:	This module defines ADDB-based interfaces for TSDB.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.*
+ */
+#ifndef TSDB_ADDB_H_
+#define TSDB_ADDB_H_
+/******************************************************************************/
+#include <stdint.h>
+
+/******************************************************************************/
+
+/* Note: We do not include addb headers directly in order to avoid
+ * problems with contamination of the other source files.
+ * So that, we just define this constant right here.
+ * A corresponding compile-time check will be added into
+ * the source file.
+ */
+#define TSDB_ACTION_ID_BASE 0x0020000
+
+void m0_addb2_add(uint64_t id, int n, const uint64_t *value);
+void m0_addb2_global_leave(void);
+
+static inline
+void tsdb_add(uint64_t id, int n, const uint64_t *value)
+{
+	m0_addb2_add(id, n, value);
+}
+
+static inline
+void tsdb_leave(void)
+{
+	m0_addb2_global_leave();
+}
+
+/******************************************************************************/
+#endif /* TSDB_ADDB_H_ */

--- a/utils/src/include/perf/tsdb-dummy.h
+++ b/utils/src/include/perf/tsdb-dummy.h
@@ -1,0 +1,35 @@
+/**
+ * Filename:	tsdb-dummy.h
+ * Description:	This module defines a noop implementation of TSDB backend.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.*
+ */
+#ifndef TSDB_DUMMY_H_
+#define TSDB_DUMMY_H_
+/******************************************************************************/
+#include <stdint.h>
+
+/******************************************************************************/
+
+static inline
+void tsdb_add(uint64_t id, int n, const uint64_t *value) { }
+static inline
+void tsdb_leave(void) { }
+
+
+#define TSDB_ACTION_ID_BASE 0
+
+/******************************************************************************/
+#endif /* TSDB_DUMMY_H_ */

--- a/utils/src/include/perf/tsdb-printf.h
+++ b/utils/src/include/perf/tsdb-printf.h
@@ -1,0 +1,63 @@
+/**
+ * Filename:	tsdb-printf.h
+ * Description:	This module defines a dummy printf-based TSDB engine.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.*
+ */
+/* This module can be used only for debugging of public TSDB API. It has
+ * zero meaning for real-life scenarios.
+ */
+#ifndef TSDB_PRINTF_H_
+#define TSDB_PRINTF_H_
+/******************************************************************************/
+#include <stdio.h>
+#include <stdint.h>
+
+/******************************************************************************/
+
+#ifndef TSDB_FOUT
+#define TSDB_FOUT stdout
+#endif
+
+#ifndef TSDB_PREFIX
+#define TSDB_PREFIX "TSDB::"
+#endif
+
+static inline
+void tsdb_add(uint64_t id, int n, const uint64_t *value)
+{
+	int i;
+
+	fprintf(TSDB_FOUT, TSDB_PREFIX "add: ID=%lx", (unsigned long) id);
+
+	for (i = 0; i < n; i++) {
+		fprintf(TSDB_FOUT, ", %lx", (unsigned long) value[i]);
+	}
+
+	fprintf(TSDB_FOUT, ";\n");
+}
+
+static inline
+void tsdb_leave(void)
+{
+	fprintf(TSDB_FOUT, "leave;\n");
+}
+
+
+#define TSDB_ACTION_ID_BASE 0
+
+
+/******************************************************************************/
+#endif /* TSDB_PRINTF_H_ */

--- a/utils/src/include/perf/tsdb.h
+++ b/utils/src/include/perf/tsdb.h
@@ -1,0 +1,196 @@
+/**
+ * Filename:	tsdb.h
+ * Description:	This module defines TSDB interfaces.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.*
+ */
+#ifndef TSDB_H_
+#define TSDB_H_
+/******************************************************************************/
+#include <stdbool.h> /* bool type */
+#include <stdint.h> /* SintN_t types */
+
+/******************************************************************************/
+/* TSDB
+ * ----
+ *  TSDB is an abstraction layer over a time series database.
+ *  At this moment it supports only one engine - ADDB.
+ *  The main function (macro, actually) is TSDB_ADD. It adds a record
+ *  into the database. Records are added in a way that it has almost
+ *  zero impact on performance. After successful program execution,
+ *  the corresponding file (for example, an ADDB stob) can be used
+ *  for further analysis.
+ *
+ *  Non-implemented functionality:
+ *	- Decoder. TSDB records contain only numbers. These numbers
+ *	can be mapped to human-readable strings.
+ *	- Push/Pop. ADDB supports changing of the current context,
+ *	however right now is optional.
+ *
+ *
+ * Enabling/Disabling TSDB
+ * -----------------------
+ *
+ *  There are 3 ways to enable/disable parts of TSDB:
+ *	- Compile-time switch (ENABLE_TSDB_{X}).
+ *	- Initial state of the engine.
+ *	- Run-time switch.
+ *  Imagine, there is a house and there is a power generator in that house
+ *  that works on gas or a similar substance. This generator automatically
+ *  starts working once you put some gas into it, and it cannot be turned
+ *  off afterwards. There is also some wires that connect the generator
+ *  with an onoff (run-time) switch that turns on/off a lamp in that house.
+ *  Using this example, these ways can be described as following:
+ *	- Compile-time switch - whether you want to install wires in the
+ *	house or not. If there are no wires then nothing will work.
+ *	- Initial state of the engine. Once you turn the power generator on,
+ *	you cannot turn it off later. It will continue using the resources.
+ *	In the same way, the TSDB engine cannot be disabled.
+ *	- Run-time switch - it is just like a switch in the room
+ *	that turns on/off the lamp. If you turn it off then you can save
+ *	some resources.
+ * Use-cases:
+ *	* Compile-time switch allows us to completely turn off tracing.
+ *	  For example, if we want to compile the project without M0.
+ *	* Initial state of the engine allows us to do almost the same thing
+ *	  as the previous one but at the startup time without recompiling
+ *	  the program.
+ *	* Run-time switch allows us to disable tracing dynamically
+ *	  when the program already runs. It can be used when we need to
+ *	  perform measurements only at specific points of timescale.
+ */
+
+/******************************************************************************/
+/* Internal TSDB API. Each TSDB engine shall implement this set of
+ * declarations.
+ */
+
+/** Add a record into the db.
+ * @param id Action ID.
+ * @param n Number of values.
+ * @param value Array of values.
+ *
+ * The db is a mapping between Action IDs and values.
+ * So that, K=id and V=(n,value).
+ * The keys form a multiset -- it is allowed to have different values
+ * with the same keys. In other words, the reverse mapping (V -> K) is
+ * surjective.
+ * The Action ID is needed only to draw the lines between different
+ * modules and operations.
+ */
+static inline void tsdb_add(uint64_t id, int n, const uint64_t *value);
+
+/** Tell the engine to leave the current thread.
+ * This call is needed only for ADDB and only for specific cases where
+ * we want to "detach" ADDB from the thread.
+ * Any other implementation of the internal TSDB API can define it
+ * as no-op.
+ */
+static inline void tsdb_leave(void);
+
+/******************************************************************************/
+/* Import a TSDB engine based on compile-time flags */
+#if defined(ENABLE_TSDB_ADDB)
+#include "perf/tsdb-addb.h"
+#elif defined(ENABLE_TSDB_PRINTF)
+#include "perf/tsdb-printf.h"
+#else
+/* Use stubs instead of the actual ADDB API
+ * when ADDB-based is disabled at compile-time.
+ */
+#include "perf/tsdb-dummy.h"
+#endif
+
+/******************************************************************************/
+/** Expression-like trace point.
+ * @param __rv Return value of the macro.
+ * @param __action_id Action ID - the mandatory part of any record.
+ * @return __rv The value is returned as it is.
+ *
+ * The __rv parameter (and the corresponding GCC extension enabled by default)
+ * allows using this macro as expression but not just as statement.
+ * Here is the common use case:
+ *
+ * @{code}
+ * void foo(int a) {
+ *	int b = 1;
+ *	int rc = 0;
+ *
+ *	// Puts (FOO_ENTER_ID, a) into the db.
+ *	TSDB_ADD_EX(NULL, FOO_ENTER_ID, a);
+ *
+ *	// some logic here to change the rc
+ *	rc = (b == a) ? 0 : -EINVAL;
+ *
+ *	// Returns rc and puts (FOO_EXIT_ID, a, b, rc) tuple into the db.
+ *	return TSDB_ADD_EX(FOO_EXIT_ID, rc, a, b, rc);
+ * }
+ * @{endcode}
+ *
+ */
+#define TSDB_ADD_EX(__rv, __action_id, ...)				\
+({									\
+	if (tsdb_is_on()) {						\
+		const uint64_t __args[] = { __VA_ARGS__ };		\
+		int __n_args  = sizeof(__args) / sizeof(__args[0]);	\
+		tsdb_add(__action_id, __n_args, __args);		\
+	}								\
+	 __rv;								\
+})
+
+/** Statement-like trace point. */
+#define TSDB_ADD(...) TSDB_ADD_EX(NULL, __VA_ARGS__)
+
+/** Detaches the current thread from the TSDB engine. */
+#define TSDB_LEAVE() tsdb_leave()
+
+/******************************************************************************/
+/** Check if TSDB is enabled.
+ * @see tsdb_set_onoff_state for details.
+ */
+bool tsdb_is_on(void);
+
+/** Check if TSDB engine was started in tsdb_init() call.
+ * This function may be used at initialization state of the underlying
+ * TSDB backend.
+ */
+bool tsdb_is_engine_on(void);
+
+/** Enable or disable TSDB at runtime.
+ * NOTE1: It only disables the process of generating new entires;
+ *  see TSDB_ADD_EX macro and tsdb_is_on() function for details.
+ *  Any existing entires will be dumped eventually. Also, the engine
+ *  cannot be turned off by this call. It can be done using ENABLE_TSDB_{X}
+ *  macro at compile-time.
+ * NOTE2: When TSDB engine is disabled at compile time, this function is noop.
+ *  It does nothing except changing one local variable.
+ */
+void tsdb_set_rt_state(bool rt_state);
+
+/** Initialize TSDB.
+ * See the "Enabling/Disabling TSDB" section for the details.
+ * @param engine_state Set "true" if TSDB engine should be available.
+ *		       Note: this value cannot be changed later.
+ * @param rt_stat Set if "true" if TSDB should be enabled at runtime.
+ *		  ::tsdb_set_rt_state can be used to change it.
+ * @return -errno if tsdb cannot be initialized; 0 otherwise.
+ */
+int tsdb_init(bool engine_state, bool rt_state);
+
+/** Finalizes TSDB. */
+void tsdb_fini(void);
+
+/******************************************************************************/
+#endif /* TSDB_H_ */

--- a/utils/src/test/CMakeLists.txt
+++ b/utils/src/test/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(fault)
+add_subdirectory(perf)

--- a/utils/src/test/perf/CMakeLists.txt
+++ b/utils/src/test/perf/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(perf-manual-test
+		perf-manual-test.c
+		$<TARGET_OBJECTS:${UTILS_TSDB}>
+	)
+
+

--- a/utils/src/test/perf/perf-manual-test.c
+++ b/utils/src/test/perf/perf-manual-test.c
@@ -1,0 +1,222 @@
+/**
+ * Filename:    perf-manual-test.c
+ * Description: This file implements several test cases for manual testing of
+ *		performance-related interfaces.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.*
+ */
+
+/* Print tsdb output into stdout instead of using ADDB. */
+#undef ENABLE_TSDB_ADDB
+#define ENABLE_TSDB_PRINTF
+
+#include "operation.h"
+#include <assert.h>
+
+static
+void tsdb_run_manual_test(void)
+{
+	/* Test basic functions */
+	{
+		/* Expected result:
+		 *	all the numbers appear on the screen
+		 */
+		(void) tsdb_init(true, true);
+		TSDB_ADD(1, 2, 3);
+		TSDB_ADD(1);
+		TSDB_ADD(0xCAFE);
+		TSDB_ADD(0xEFAC, UINT64_MAX, 0);
+		TSDB_ADD(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+		tsdb_fini();
+	}
+	/* Test rt state */
+	{
+		/* Expected result:
+		 *	all the numbers except 0xDEAD
+		 *	appear on the screen
+		 */
+		(void) tsdb_init(true, false);
+		TSDB_ADD(0xDEAD);
+		tsdb_set_rt_state(true);
+		TSDB_ADD(0xFF);
+		tsdb_set_rt_state(false);
+		TSDB_ADD(0xDEAD);
+		tsdb_fini();
+	}
+	/* Test engine state */
+	{
+		/* Expected result:
+		 *	all the numbers except 0xDEAD
+		 *	appear on the screen
+		 */
+		(void) tsdb_init(false, false);
+		TSDB_ADD(0xDEAD);
+		tsdb_set_rt_state(true);
+		TSDB_ADD(0xDEAD);
+		tsdb_set_rt_state(false);
+		TSDB_ADD(0xDEAD);
+		tsdb_fini();
+
+	}
+}
+
+/* list of tags of this test module */
+enum {
+	UT_CALL = 0x1,
+	CALL_XA = 0xA,
+	CALL_XB = 0xB,
+	MAP_XID = 0xC,
+};
+
+struct modctx call_xm = MODCTX_INIT(TSDB_MOD_CUSTOM_START);
+static void call_b(struct opstack *op, int arg)
+{
+	opstack_push(op, &call_xm, CALL_XB);
+	printf("%s: called with %x\n", __FUNCTION__, arg);
+	TSDB_ADD(0xCB1, opstack_head(op)->call_id, arg);
+	TSDB_ADD(0xCB2, opstack_head(op)->call_id,
+		 opstack_caller(op)->call_id);
+
+	printf("current opcall: " OPCALL_DBG_FMT "\n",
+	       OPCALL_DBG_P(opstack_curr(op)));
+	printf("\tExpected(%d): f=%d, m=%d\n", __LINE__, CALL_XB,
+	       TSDB_MOD_CUSTOM_START);
+
+	printf("head opcall: " OPCALL_DBG_FMT "\n",
+	       OPCALL_DBG_P(opstack_head(op)));
+	printf("\tExpected(%d): f=%d, m=%d\n", __LINE__, UT_CALL,
+	       TSDB_MOD_UT);
+
+	opstack_map_head2external(op, MAP_XID, 0xFF);
+	printf("\tExpected(%d): %x, %x, %x, %x, %x\n", __LINE__,
+	       /* Action ID */
+	       TSDB_MK_AID(TSDB_MOD_UT, UT_CALL),
+	       /* PERFC subtag */
+	       PERFC_MAP,
+	       /* ID of the call */
+	       1,
+	       /* Map ID */
+	       MAP_XID,
+	       /* Foreign op ID */
+	       0xFF);
+
+	opstack_pop(op);
+}
+
+static void call_a(struct opstack *op, int arg)
+{
+	opstack_push(op, &call_xm, CALL_XA);
+	call_b(op, arg);
+	opstack_pop(op);
+}
+
+static
+void opcall_run_manual_test(void)
+{
+	/* Test basic functions */
+	{
+		/* Expected result:
+		 *	code compiles and executes successfully
+		 *	no output (tsdb is not initialized)
+		 */
+		enum {
+			MY_TAG_A = 0xA,
+			MY_TAG_B = 0xB,
+		};
+		struct modctx m = MODCTX_INIT(TSDB_MOD_UT);
+		struct opstack op = OPSTACK_INIT(&m, MY_TAG_A);
+		opstack_push(&op, &m, MY_TAG_B);
+		opstack_pop(&op);
+		opstack_end(&op);
+	}
+
+	/* Test begin/end, push/pop */
+	{
+		/* Expected result:
+		 *	code compiles and executes successfully
+		 *	no output (tsdb is not initialized)
+		 */
+		enum {
+			MY_TAG_A = 0xA,
+			MY_TAG_B = 0xB,
+		};
+		struct modctx m = MODCTX_INIT(TSDB_MOD_UT);
+		struct opstack op = OPSTACK_INIT_EMPTY();
+		opstack_begin(&op, &m, MY_TAG_A);
+		opstack_push(&op, &m, MY_TAG_B);
+		opstack_pop(&op);
+		opstack_end(&op);
+	}
+
+	/* Test calling another function */
+	{
+		tsdb_init(true, true);
+
+		int i;
+		struct modctx m = MODCTX_INIT(TSDB_MOD_UT);
+		struct opstack op = OPSTACK_INIT_EMPTY();
+		opstack_begin(&op, &m, UT_CALL);
+		printf("\tExpected(%d) %x, %x, %x\n", __LINE__,
+		       /* Action ID */
+		       TSDB_MK_AID(TSDB_MOD_UT, UT_CALL),
+		       /* 'b'egin subtag */
+		       PERFC_EE_OP_BEGIN,
+		       /* It is the first call */
+		       1);
+		for (i = 0; i < 3; i++) {
+			call_a(&op, 0xF0 + i);
+		}
+		opstack_end(&op);
+		printf("\tExpected(%d) %x, %x, %x\n", __LINE__,
+		       /* Action ID */
+		       TSDB_MK_AID(TSDB_MOD_UT, UT_CALL),
+		       /* 'e'nd subtag */
+		       PERFC_EE_OP_END,
+		       /* It is still the first call */
+		       1);
+
+		printf("Expected AID: UTCALL=%x\n",
+		       TSDB_MK_AID(TSDB_MOD_UT, UT_CALL));
+
+		tsdb_fini();
+	}
+
+	/* Test expression-style definitions compilation */
+	{
+		/* Expected result:
+		 *	code compiles and executes successfully
+		 *	no output (tsdb is not initialized)
+		 */
+		struct modctx m = MODCTX_INIT(TSDB_MOD_UT);
+		struct opstack op = OPSTACK_INIT_EMPTY();
+		int rc;
+		int val = 0xBAD;
+		opstack_begin(&op, &m, UT_CALL);
+		rc = val;
+		val = opstack_end_rc(&op, rc);
+		assert(rc == val);
+		val = TSDB_ADD_EX(rc, 0);
+		assert(rc == val);
+	}
+}
+
+int main(void)
+{
+	printf("TSDB manual tests:\n");
+	tsdb_run_manual_test();
+	printf("OPCALL manual tests :\n");
+	opcall_run_manual_test();
+	return 0;
+}

--- a/utils/src/test/perf/perf-manual-test.output.txt
+++ b/utils/src/test/perf/perf-manual-test.output.txt
@@ -1,0 +1,40 @@
+TSDB manual tests:
+TSDB::add: ID=1, 2, 3;
+TSDB::add: ID=1;
+TSDB::add: ID=cafe;
+TSDB::add: ID=efac, ffffffffffffffff, 0;
+TSDB::add: ID=0, 1, 2, 3, 4, 5, 6, 7, 8, 9;
+TSDB::add: ID=ff;
+OPCALL manual tests :
+TSDB::add: ID=5001, b, 1;
+	Expected(171) 5001, b, 1
+call_b: called with f0
+TSDB::add: ID=cb1, 1, f0;
+TSDB::add: ID=cb2, 1, 1;
+current opcall: c=2, f=11, m=6, n='call_b'
+	Expected(94): f=11, m=6
+head opcall: c=1, f=1, m=5, n='opcall_run_manual_test'
+	Expected(99): f=1, m=5
+TSDB::add: ID=5001, f, 1, c, ff;
+	Expected(103): 5001, f, 1, c, ff
+call_b: called with f1
+TSDB::add: ID=cb1, 1, f1;
+TSDB::add: ID=cb2, 1, 3;
+current opcall: c=4, f=11, m=6, n='call_b'
+	Expected(94): f=11, m=6
+head opcall: c=1, f=1, m=5, n='opcall_run_manual_test'
+	Expected(99): f=1, m=5
+TSDB::add: ID=5001, f, 1, c, ff;
+	Expected(103): 5001, f, 1, c, ff
+call_b: called with f2
+TSDB::add: ID=cb1, 1, f2;
+TSDB::add: ID=cb2, 1, 5;
+current opcall: c=6, f=11, m=6, n='call_b'
+	Expected(94): f=11, m=6
+head opcall: c=1, f=1, m=5, n='opcall_run_manual_test'
+	Expected(99): f=1, m=5
+TSDB::add: ID=5001, f, 1, c, ff;
+	Expected(103): 5001, f, 1, c, ff
+TSDB::add: ID=5001, e, 1;
+	Expected(182) 5001, e, 1
+Expected AID: UTCALL=5001

--- a/utils/src/test/perf/perf-manual-test.sh
+++ b/utils/src/test/perf/perf-manual-test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+script_dir="$(readlink -f $(dirname $0))"
+test_binary="/tmp/eos-fs/build-eos-utils/test/perf/perf-manual-test"
+# reference output file
+ref_output_file="$script_dir/perf-manual-test.output.txt"
+
+verify() {
+    "$test_binary" > /tmp/actual
+    cp "$ref_output_file" /tmp/expected
+    diff -u /tmp/expected /tmp/actual
+    rc=$?
+
+    if ((rc == 0)); then
+        echo "OK"
+    fi
+
+    return $rc
+}
+
+update() {
+    "$test_binary" > /tmp/actual
+    cp /tmp/actual "$ref_output_file"
+    echo "Done"
+    return 0
+}
+
+case $1 in
+    update)
+        update;;
+    verify)
+        verify;;
+    *)
+        echo "Use 'verify' or 'update' commands";;
+esac

--- a/utils/src/tsdb/CMakeLists.txt
+++ b/utils/src/tsdb/CMakeLists.txt
@@ -1,0 +1,6 @@
+SET(UTILS_TSDB_SRCS
+	tsdb.c
+)
+
+add_library(utils-tsdb OBJECT ${UTILS_TSDB_SRCS})
+

--- a/utils/src/tsdb/tsdb.c
+++ b/utils/src/tsdb/tsdb.c
@@ -1,0 +1,67 @@
+/**
+ * Filename:	tsdb.c
+ * Description:	This module implements TSDB frontend interface.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.*
+ */
+#include "perf/tsdb.h"
+
+/** TSDB state */
+struct tsdb_module {
+	/** Engine state.
+	 * The state is a readonly properly. It can be set (or cleared)
+	 * in a call to ::tsdb_init, and it cannot be changed later.
+	 */
+	bool is_engine_on;
+
+	/** Runtime state.
+	 * This is mutable properly. It can be changed using
+	 * ::tsdb_set_rt_state.
+	 */
+	bool is_rt_on;
+};
+
+/** TSDB singleton. */
+static struct tsdb_module g_tsdb;
+
+bool tsdb_is_on(void)
+{
+	return g_tsdb.is_rt_on && g_tsdb.is_engine_on;
+}
+
+bool tsdb_is_engine_on(void)
+{
+	return g_tsdb.is_engine_on;
+}
+
+void tsdb_set_rt_state(bool state)
+{
+	g_tsdb.is_rt_on = state;
+}
+
+int tsdb_init(bool engine_state, bool rt_state)
+{
+	g_tsdb.is_engine_on = engine_state;
+	g_tsdb.is_rt_on = rt_state;
+
+	return 0; /* nothing can fail at this moment */
+}
+
+void tsdb_fini(void)
+{
+	g_tsdb.is_rt_on = false;
+	g_tsdb.is_engine_on = false;
+}
+


### PR DESCRIPTION
# Problem statement

Ref: https://jts.seagate.com/browse/EOS-8822

Original patch: https://github.com/Seagate/cortx-utils/pull/84

COTRXFS does not have a way to control
ADDB and propagate contexts between different
calls.

See the "EFS Redesign for ADDB integration" link in the Jira ticket for more details.

# Solution overview

This patch introduces 3 APIs:
  - TSDB (wrapper for ADDB)
  - Operations (context propagation)
  - Perf counters (data scheme for traces).

Dependencies between these APIs:
  - TSDB provides a mechanism for tracing.
  - Perf counters provides a policy.
  - Operations wrap calls to TSDB and Perf counters
    into a developer-friendly format.

# How has this been tested?

This PR contains headers and source files required for integration of COTRXFS-related code with ADDB. This PR does not introduce the integration itself -- it only provides all needed mechanisms for that.

The PR was tested manually with help of the test utility provided in the PR. Automatic unittesting with a mocked TSDB may be added in consequent patches.

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [x] **Code review:** _All discussions have been resolved_
- [x] **Testing:** _Manual testing is done for current version of the patch_
- [x] **Documentation:** _This patch and merge request and JIRA ticket mentioned above have up to date description_