### PR TITLE
DSAL: Changes for mero based read operation for objects

### DIFF
--- a/dsal/src/dstore/dstore_base.c
+++ b/dsal/src/dstore/dstore_base.c
@@ -205,11 +205,12 @@ out:
 	return rc;
 }
 
-int dstore_io_op_write(struct dstore_obj *obj,
-		       struct dstore_io_vec *bvec,
-		       dstore_io_op_cb_t cb,
-		       void *cb_ctx,
-		       struct dstore_io_op **out)
+static int dstore_io_op_init_and_submit(struct dstore_obj *obj,
+                                        struct dstore_io_vec *bvec,
+                                        dstore_io_op_cb_t cb,
+                                        void *cb_ctx,
+                                        struct dstore_io_op **out,
+                                        enum dstore_io_op_type op_type)
 {
 	int rc;
 	struct dstore *dstore;
@@ -221,11 +222,14 @@ int dstore_io_op_write(struct dstore_obj *obj,
 	dassert(out);
 	dassert(dstore_obj_invariant(obj));
 	dassert(dstore_io_vec_invariant(bvec));
+	/* Only WRITE/READ is supported so far */
+	dassert(op_type == DSTORE_IO_OP_WRITE ||
+		op_type == DSTORE_IO_OP_READ);
 
 	dstore = obj->ds;
 
 	RC_WRAP_LABEL(rc, out, dstore->dstore_ops->io_op_init, obj,
-		      DSTORE_IO_OP_WRITE, bvec, cb, cb_ctx, &result);
+		      op_type, bvec, cb, cb_ctx, &result);
 	RC_WRAP_LABEL(rc, out, dstore->dstore_ops->io_op_submit, result);
 
 	*out = result;
@@ -236,12 +240,43 @@ out:
 		dstore->dstore_ops->io_op_fini(result);
 	}
 
+	dassert((!(*out)) || dstore_io_op_invariant(*out));
+	return rc;
+}
+
+int dstore_io_op_write(struct dstore_obj *obj,
+                       struct dstore_io_vec *bvec,
+                       dstore_io_op_cb_t cb,
+                       void *cb_ctx,
+                       struct dstore_io_op **out)
+{
+	int rc;
+
+	rc = dstore_io_op_init_and_submit(obj, bvec, cb, cb_ctx, out,
+					  DSTORE_IO_OP_WRITE);
+
 	log_debug("write (" OBJ_ID_F " <=> %p, "
 		  "vec=%p, cb=%p, ctx=%p, *out=%p) rc=%d",
 		  OBJ_ID_P(dstore_obj_id(obj)), obj,
 		  bvec, cb, cb_ctx, rc == 0 ? *out : NULL, rc);
 
-	dassert((!(*out)) || dstore_io_op_invariant(*out));
+	return rc;
+}
+
+int dstore_io_op_read(struct dstore_obj *obj, struct dstore_io_vec *bvec,
+                      dstore_io_op_cb_t cb, void *cb_ctx,
+                      struct dstore_io_op **out)
+{
+	int rc;
+
+	rc = dstore_io_op_init_and_submit(obj, bvec, cb, cb_ctx, out,
+					  DSTORE_IO_OP_READ);
+
+	log_debug("read (" OBJ_ID_F " <=> %p, "
+		  "vec=%p, cb=%p, ctx=%p, *out=%p) rc=%d",
+		  OBJ_ID_P(dstore_obj_id(obj)), obj,
+		  bvec, cb, cb_ctx, rc == 0 ? *out : NULL, rc);
+
 	return rc;
 }
 

--- a/dsal/src/dstore/dstore_internal.h
+++ b/dsal/src/dstore/dstore_internal.h
@@ -305,9 +305,10 @@ bool dstore_io_op_invariant(const struct dstore_io_op *op)
 {
 	/* Condition:
 	 *	Op type should be a supported operation.
-	 * NOTE: only WRITE is supported so far.
+	 * NOTE: only WRITE/READ is supported so far.
 	 */
-	bool op_is_supported = (op->type == DSTORE_IO_OP_WRITE);
+	bool op_is_supported = (op->type == DSTORE_IO_OP_WRITE ||
+				op->type == DSTORE_IO_OP_READ);
 	/* Condition:
 	 *	Data vector should be a valid object whether it has
 	 *	data or not.

--- a/dsal/src/dstore/plugins/eos/eos_dstore.c
+++ b/dsal/src/dstore/plugins/eos/eos_dstore.c
@@ -515,6 +515,26 @@ static const struct m0_clovis_op_ops eos_io_op_cbs = {
 	.oop_failed = on_oop_failed,
 	.oop_stable = on_oop_finished,
 };
+/* Return an appropriate object operation value with respect to io operation
+ * value
+ */
+static enum m0_clovis_obj_opcode
+	dstore_io_op_type2m0_op_type(enum dstore_io_op_type type)
+{
+	enum m0_clovis_obj_opcode obj_opcode;
+	switch (type) {
+		case DSTORE_IO_OP_WRITE:
+			obj_opcode = M0_CLOVIS_OC_WRITE;
+			break;
+		case DSTORE_IO_OP_READ:
+			obj_opcode = M0_CLOVIS_OC_READ;
+			break;
+		default:
+			/* Unsupported operation type */
+			dassert(0);
+	}
+	return obj_opcode;
+}
 
 static int eos_ds_io_op_init(struct dstore_obj *dobj,
 			     enum dstore_io_op_type type,
@@ -530,7 +550,7 @@ static int eos_ds_io_op_init(struct dstore_obj *dobj,
 	const m0_time_t schedule_now = 0;
 	const uint64_t empty_mask = 0;
 
-	if (!M0_IN(type, (DSTORE_IO_OP_WRITE))) {
+	if (!M0_IN(type, (DSTORE_IO_OP_WRITE, DSTORE_IO_OP_READ))) {
 		log_err("%s", (char *) "Unsupported IO operation");
 		rc = RC_WRAP_SET(-EINVAL);
 		goto out;
@@ -553,8 +573,9 @@ static int eos_ds_io_op_init(struct dstore_obj *dobj,
 
 	dstore_io_vec2bufext(&result->base.data, &result->vec);
 
-	RC_WRAP_LABEL(rc, out, m0_clovis_obj_op, &obj->cobj, M0_CLOVIS_OC_WRITE,
-		      &result->vec.extents, &result->vec.data,
+	RC_WRAP_LABEL(rc, out, m0_clovis_obj_op, &obj->cobj,
+		      dstore_io_op_type2m0_op_type(type), &result->vec.extents,
+		      &result->vec.data,
 		      &result->attrs, empty_mask, &result->cop);
 
 	result->cop->op_datum = result;


### PR DESCRIPTION
# DSAL Change Summary

## Problem Statement

_[EOS-8184](https://jts.seagate.com/browse/EOS-8184):_
_DSAL: Mero-based Read operation for objects_

## Problem Description

_As a part of design change proposal under [EOS-4776](https://jts.seagate.com/browse/EOS-4776) similar to WRITE path implementation done in [EOS-8181](https://jts.seagate.com/browse/EOS-8181), READ path implementation was yet to be implemented_

## Solution Overview

_Have added the READ path implementation by adhering to the design implemented in parent task, added UT validation to make sure WRITE/READ are working on block boundary_

## Unit Test Cases
_Already existing UTs for validating this code path in DSAL are passing_
_Added new test case to validate READ empty file to ensure no error from DSAL apis and getting as expected rc as -ENOENT_
_Added new test case to validate WRITE/READ data integrity check passes_

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [ ] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _As mentioned in description existing and newly implemented UTs are passing_
- [x] **Documentation:** _This patch, merge request, Jira ticket [EOS-8184](https://jts.seagate.com/browse/EOS-8184) and [EOS-11436](https://jts.seagate.com/browse/EOS-11436) (spike task)  have up to date description_