### PR TITLE
EOS-11407: Fix M0 panic during finalization.

### DIFF
--- a/efs/src/fs/fs.c
+++ b/efs/src/fs/fs.c
@@ -102,7 +102,7 @@ void fs_ns_scan_cb(struct namespace *ns, size_t ns_size)
 	log_info("%d trying to load FS: " STR256_F,
 		 __LINE__, STR256_P(fs_name));
 
-	fs_node = malloc(sizeof(struct efs_fs_node));
+	fs_node = calloc(1, sizeof(struct efs_fs_node));
 	if (fs_node == NULL) {
 	    log_err("%d failed to load FS: " STR256_F
 		    " , could not allocate memory for efs_fs_node!",
@@ -110,7 +110,7 @@ void fs_ns_scan_cb(struct namespace *ns, size_t ns_size)
 	    goto out_failed;
 	}
 
-	fs_node->efs_fs.ns = malloc(ns_size);
+	fs_node->efs_fs.ns = calloc(1, ns_size);
 	if (fs_node->efs_fs.ns == NULL) {
 	    log_err("%d failed to load FS: " STR256_F
 		    " , could not allocate memory for ns object!",
@@ -120,7 +120,7 @@ void fs_ns_scan_cb(struct namespace *ns, size_t ns_size)
 
 	memcpy(fs_node->efs_fs.ns, ns, ns_size);
 
-	fs_node->efs_fs.kvtree = malloc(sizeof(struct kvtree));
+	fs_node->efs_fs.kvtree = calloc(1, sizeof(struct kvtree));
 	if (!fs_node->efs_fs.kvtree) {
 	    log_err("%d failed to load FS: " STR256_F
 		    " , could not allocate memory for kvtree object!",


### PR DESCRIPTION
# Problem

Ref: https://jts.seagate.com/browse/EOS-11407

M0 panics because threads are not finalized properly.

# Solution

Add a workaround for autoshun-ing worker threads. Add a call to ADDB from the thread where m0init is called to avoid deadlocks.

Note: The patch includes a fix for EFS as well because EFS endpoints does not work as it is under some circumstances. We use unitialized memory created by mallocs and it leads to UB in the function that scans exports causing a SIGSEGV.

# Testing

The patch was tested with NFS Ganesha under GDB, and with the NFS Ganesha service.

Here is the result of manual testing:

```
time systemctl restart nfs-ganesha

real    0m7.111s
user    0m0.005s
sys     0m0.008s

time systemctl stop nfs-ganesha

real    0m3.072s
user    0m0.005s
sys     0m0.009s

As you see the time it takes stop or restart NFS Ganesha
service has been reduced significantly.
Here is the confirmation from `systemctl status nfs-ganesha`:
● nfs-ganesha.service - NFS-Ganesha file server
   Loaded: loaded (/usr/lib/systemd/system/nfs-ganesha.service;
disabled; vendor preset: disabled)
   Active: inactive (dead) since Tue 2020-08-11 07:49:45 MDT; 7s ago
     Docs: http://github.com/nfs-ganesha/nfs-ganesha/wiki
  Process: 29575 ExecStop=/bin/dbus-send --system
--dest=org.ganesha.nfsd --type=method_call /org/ganesha/nfsd/admin
org.ganesha.nfsd.admin.shutdown (code=exited, status=0/SUCCESS)
  Process: 29524 ExecStartPost=/bin/bash -c /usr/bin/sleep 2 &&
/bin/dbus-send --system   --dest=org.ganesha.nfsd --type=method_call
/org/ganesha/nfsd/admin  org.ganesha.nfsd.admin.init_fds_limit
(code=exited, status=0/SUCCESS)
  Process: 29521 ExecStartPost=/bin/bash -c prlimit --pid $MAINPID
--nofile=$NOFILE:$NOFILE (code=exited, status=0/SUCCESS)
  Process: 29517 ExecStart=/bin/bash -c ${NUMACTL} ${NUMAOPTS}
/usr/bin/ganesha.nfsd ${OPTIONS} ${EPOCH} (code=exited,
status=0/SUCCESS)
 Main PID: 29518 (code=exited, status=0/SUCCESS)

As you see, NFS Ganesha exits with 0 exitcode without getting
stuck with SIGSEGV and/or SIGABRT.
```

UT passed as well.

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [x] **Code review:** _All discussions have been resolved_
- [x] **Testing:** _Manual testing is done for current version of the patch, UT is pending_
- [x] **Documentation:** _This patch and merge request and JIRA ticket mentioned above have up to date description_
