### PR TITLE
EOS-11661: EOS-NFS: Update copyright message in CORTX-POSIX directory

### DIFF
--- a/dsal/design/dsal_async_io.h
+++ b/dsal/design/dsal_async_io.h
@@ -1,8 +1,25 @@
+/*
+ * Filename: dsal_async_io.h
+ * Description: Async IO module for Data storage abstraction layer
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
 #ifndef DSAL_ASYNC_IO_H_
 #define DSAL_ASYNC_IO_H_
-/******************************************************************************/
-/* TODO: Add Copyright. */
-/******************************************************************************/
+
 /** Async IO module for Data storage abstraction layer.
  * The module API allows users to submit a single IO operation into the
  * underlying data storage and get a notification (success/failure) in

--- a/dsal/design/dsal_io.h
+++ b/dsal/design/dsal_io.h
@@ -1,8 +1,25 @@
+/*
+ * Filename: dsal_io.h
+ * Description: IO module for Data storage abstraction layer
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
 #ifndef DSAL_IO_H_
 #define DSAL_IO_H_
-/******************************************************************************/
-/* TODO: Add Copyright. */
-/******************************************************************************/
+
 /* Data Types */
 
 /** Global context for the data storage module.

--- a/dsal/src/dsal/dsal.c
+++ b/dsal/src/dsal/dsal.c
@@ -1,16 +1,21 @@
 /*
  * Filename:         dsal.c
  * Description:      Contains DSAL specific implementation.
-
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
-*/
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 #include "dsal.h"  /* header for dsal_init/dsal_fini */
 #include <debug.h> /* dassert */

--- a/dsal/src/dsal/dstore_bufvec.c
+++ b/dsal/src/dsal/dstore_bufvec.c
@@ -1,18 +1,27 @@
 /*
  * Filename:         dstore_bufvec.c
  * Description:      IO Vectors and buffers (implementation).
-
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
  *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
+/* 
  * This file contains implementation public API functions for
  * IO Vector and IO Buffer data types.
  */
+ 
 #include "dstore_bufvec.h"
 #include <stdlib.h> /* malloc */
 #include <errno.h> /* errno values */

--- a/dsal/src/dstore/dstore_base.c
+++ b/dsal/src/dstore/dstore_base.c
@@ -2,17 +2,21 @@
  * Filename:         dstore_base.c
  * Description:      Contains implementation of basic dstore
  *                   framework APIs.
-
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- Contains implementation of basic dstore framework APIs.
-*/
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 #include "dstore.h"
 #include <assert.h> /* TODO: to be replaced with dassert() */

--- a/dsal/src/dstore/dstore_internal.h
+++ b/dsal/src/dstore/dstore_internal.h
@@ -1,16 +1,23 @@
 /*
  * Filename:         dstore_internal.h
  * Description:      Private DSAL API.
-
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
  *
- * This file defines an API that is used and implemented by DSAL
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
+/* This file defines an API that is used and implemented by DSAL
  * backends ("plugins").
  * Each backend must implement the vtable (dstore_ops) and correspondingly
  * extend the basic data types used by the vtable (ops and objects).

--- a/dsal/src/dstore/plugins/eos/eos_dstore.c
+++ b/dsal/src/dstore/plugins/eos/eos_dstore.c
@@ -1,18 +1,26 @@
 /*
  * Filename:         eos_dstore.c
  * Description:      Implementation of EOS dstore.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- This file contains APIs which implement DSAL's dstore framework,
- on top of eos clovis object APIs.
-*/
+/*
+ * This file contains APIs which implement DSAL's dstore framework,
+ * on top of eos clovis object APIs.
+ */
 
 #include <sys/param.h> /* DEV_BSIZE */
 #include "eos/helpers.h" /* M0 wrappers from eos-utils */

--- a/dsal/src/include/dsal.h
+++ b/dsal/src/include/dsal.h
@@ -1,16 +1,21 @@
 /*
  * Filename:         dsal.h
  * Description:      Provides DSAL specific implementation.
-
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
-*/
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 #ifndef _DSAL_H
 #define _DSAL_H

--- a/dsal/src/include/dstore.h
+++ b/dsal/src/include/dstore.h
@@ -2,15 +2,22 @@
  * Filename:         dstore.h
  * Description:      data store module of DSAL
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
- *
- * This file describes the public API of DSTORE module -- DSAL
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
+/* This file describes the public API of DSTORE module -- DSAL
  * (data store abstraction layer).
  *
  * Overview

--- a/dsal/src/include/dstore_bufvec.h
+++ b/dsal/src/include/dstore_bufvec.h
@@ -2,18 +2,27 @@
  * Filename:         dstore_bufvec.h
  * Description:      IO Vectors and buffers (API).
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
- *
- * This file is an optional part of DSTORE public API.
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
+/*
+* This file is an optional part of DSTORE public API.
  * It describes data types and functions needed for interaction
  * with IO-related interfaces (IO operations).
  */
+
 #ifndef DSTORE_BUFVEC_H_
 #define DSTORE_BUFVEC_H_
 /******************************************************************************/

--- a/dsal/src/include/internal/eos/eos_dstore.h
+++ b/dsal/src/include/internal/eos/eos_dstore.h
@@ -2,17 +2,25 @@
  * Filename:         eos_dstore.h
  * Description:      Provides EOS specific implementation of
  * 		     dstore module of DSAL.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- This EOS specific implementation is based on m0_clovis's object entity.
-*/
+/*
+ *This EOS specific implementation is based on m0_clovis's object entity.
+ */
 
 #ifndef _EOS_DSTORE_H
 #define _EOS_DSTORE_H

--- a/dsal/src/test/dsal_test_basic.c
+++ b/dsal/src/test/dsal_test_basic.c
@@ -1,17 +1,22 @@
-/*****************************************************************************/
 /*
  * Filename:		dsal_test_basic.c
  * Description:		Test group for very basic DSAL tests.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
-/******************************************************************************/
+
 #include <stdio.h> /* *printf */
 #include <memory.h> /* mem* functions */
 #include <assert.h> /* asserts */

--- a/dsal/src/test/dsal_test_lib.c
+++ b/dsal/src/test/dsal_test_lib.c
@@ -1,18 +1,22 @@
-/*****************************************************************************/
 /*
  * Filename:		dsal_test_lib.c
  * Description:		Code shared across the dsal_test_* modules.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
-/******************************************************************************/
 #include "dsal_test_lib.h"
 #include <stdio.h> /* *printf */
 #include <assert.h> /* assert */

--- a/dsal/src/test/dsal_test_lib.h
+++ b/dsal/src/test/dsal_test_lib.h
@@ -3,17 +3,26 @@
  * Description:		Defines a set of functions used across the DSAL
  *			unit tests modules (dsal_test_*.c).
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
+/*
  * Defines a small set of functions to be used across all the testcases/groups
  * for DSAL layer (dsal test library == dtlib).
-*/
+ */
+
 #ifndef DSAL_TEST_LIB_H_
 #define DSAL_TEST_LIB_H_
 /******************************************************************************/

--- a/dsal/src/test/dsal_test_space_stats.c
+++ b/dsal/src/test/dsal_test_space_stats.c
@@ -1,17 +1,22 @@
-/*****************************************************************************/
 /*
  * Filename:		dsal_test_space_stats.c
  * Description:		Test group for storage space utilization stats.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
-/******************************************************************************/
+
 #include <stdio.h> /* *printf */
 #include <memory.h> /* mem* functions */
 #include <assert.h> /* asserts */

--- a/efs/src/efs/efs.c
+++ b/efs/src/efs/efs.c
@@ -1,17 +1,21 @@
 /*
  * Filename:         efs.c
- * Description:      EOS file system interfaces
-
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- This file contains EFS file system interfaces.
-*/
+ * Description:      EFS file system interfaces
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 #include <stdio.h>
 #include <errno.h>

--- a/efs/src/efs/efs_fh.c
+++ b/efs/src/efs/efs_fh.c
@@ -2,12 +2,19 @@
  * Filename: efs_fh.h
  * Description: EFS File Handle API implementation.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <kvstore.h>

--- a/efs/src/efs/efs_fops.c
+++ b/efs/src/efs/efs_fops.c
@@ -1,17 +1,21 @@
 /*
  * Filename:         efs_fops.c
- * Description:      EOS file system file operations
-
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- This file contains EFS file system file operations
-*/
+ * Description:      EFS file system file operations
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 #include <string.h> /* memset */
 #include <kvstore.h> /* kvstore */

--- a/efs/src/efs/efs_internal.c
+++ b/efs/src/efs/efs_internal.c
@@ -1,17 +1,22 @@
 /*
  * Filename:         efs_internal.c
- * Description:      EOS file system internal APIs
+ * Description:      EFS file system internal APIs
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- This file contains EFS file system internal APIs
-*/
 #include <stdio.h>
 #include <errno.h>
 #include <unistd.h>

--- a/efs/src/efs/efs_internal.h
+++ b/efs/src/efs/efs_internal.h
@@ -1,17 +1,21 @@
 /*
  * Filename:         efs_internal.h
- * Description:      EOS file system internal APIs
-
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- This file contains EFS file system internal APIs
-*/
+ * Description:      EFS file system internal APIs
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 #ifndef _EFS_INTERNAL_H
 #define _EFS_INTERNAL_H

--- a/efs/src/efs/efs_ops.c
+++ b/efs/src/efs/efs_ops.c
@@ -1,17 +1,21 @@
 /*
  * Filename:         efs_ops.c
- * Description:      EOS file system operations
-
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- This file contains EFS file system operations
-*/
+ * Description:      EFS file system operations
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 #include <common/log.h> /* log_debug() */
 #include <kvstore.h> /* struct kvstore */

--- a/efs/src/efs/efs_xattr.c
+++ b/efs/src/efs/efs_xattr.c
@@ -1,17 +1,21 @@
 /*
  * Filename:         efs_xattr.c
- * Description:      EOS file system XATTR interfaces
-
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- This file contains EFS file system XATTR interfaces.
-*/
+ * Description:      EFS file system XATTR interfaces
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 #include <common/log.h> /* log_*() */
 #include <common/helpers.h> /* RC_LABEL*() */

--- a/efs/src/efscli/efscli.py
+++ b/efs/src/efscli/efscli.py
@@ -4,15 +4,19 @@
 # Filename:         efscli.py
 # Description:      Command line interface to manage EFS.
 #
-# Do NOT modify or remove this copyright and confidentiality notice!
-# Copyright (c) 2019, Seagate Technology, LLC.
-# The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
-# Portions are also trade secret. Any use, duplication, derivation,
-# distribution or disclosure of this code, for any reason, not expressly
-# authorized is prohibited. All other rights are expressly reserved by
-# Seagate Technology, LLC.
-#
-# Author: Yogesh.lahane@seagate.com
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com. 
 #
 
 import sys

--- a/efs/src/fs/fs.c
+++ b/efs/src/fs/fs.c
@@ -2,16 +2,19 @@
  * Filename: fs.c
  * Description: EFS Filesystem functions API.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Satendra Singh <satendra.singh@seagate.com>
- * Author: Jatinder Kumar <jatinder.kumar@seagate.com>
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <errno.h> /* errono */

--- a/efs/src/include/efs.h
+++ b/efs/src/include/efs.h
@@ -1,17 +1,21 @@
 /*
  * Filename:         efs.h
- * Description:      EOS file system interfaces
-
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- This file contains EFS file system interfaces.
-*/
+ * Description:      EFS file system interfaces
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 #ifndef _EFS_H
 #define _EFS_H

--- a/efs/src/include/efs_fh.h
+++ b/efs/src/include/efs_fh.h
@@ -2,13 +2,21 @@
  * Filename: efs_fh.h
  * Description: EFS File Handle API.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
+
 /* Low-level Design
  *
  * EFS (EOSFS) File Handle Overview.

--- a/efs/src/include/internal/controller.h
+++ b/efs/src/include/internal/controller.h
@@ -1,17 +1,21 @@
-/**
+/*
  * Filename: controller.h
  * Description: Controller headers:
  * 		Defines the controller types and it's api's.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef _CONTROLLER_H_

--- a/efs/src/include/internal/fs.h
+++ b/efs/src/include/internal/fs.h
@@ -2,15 +2,19 @@
  * Filename: fs.h
  * Description: EFS filesystemfunctions API.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Satendra Singh <satendra.singh@seagate.com>
- * Author: Jatinder Kumar <jatinder.kumar@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef _FS_H_

--- a/efs/src/management/endpoint.c
+++ b/efs/src/management/endpoint.c
@@ -1,16 +1,20 @@
-/**
+/*
  * Filename: endpoint.c
  * Description: Export controller.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <stdio.h> /* sprintf */

--- a/efs/src/management/fs.c
+++ b/efs/src/management/fs.c
@@ -1,16 +1,20 @@
-/**
+/*
  * Filename: fs.c
  * Description: Echo controller.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <stdio.h> /* sprintf */

--- a/efs/src/management/server.c
+++ b/efs/src/management/server.c
@@ -1,19 +1,23 @@
-/**
+/*
  * Filename: main.c
  * Description: Main managementi:
  * 		Registers the controllers to the management framework.
  * 		Wait's for the incoming requests and on the new http
  * 		Request invokes the corresponding controller api hadler.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <stdio.h>

--- a/efs/src/test/ut/efs_xattr_ops.h
+++ b/efs/src/test/ut/efs_xattr_ops.h
@@ -2,15 +2,21 @@
  * Filename: efs_xattr_ops.h
  * Description: Declaration of ops for xattr file and directory tests
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Subhash Arya <subhash.arya@seagate.com>
-*/
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
 #include "ut_efs_helper.h"
 #include <sys/xattr.h> /* XATTR_CREATE */
 

--- a/efs/src/test/ut/ut_efs_attr_ops.c
+++ b/efs/src/test/ut/ut_efs_attr_ops.c
@@ -2,15 +2,21 @@
  * Filename: ut_efs_attr_ops.c
  * Description: Implementation tests for file attributes
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Shraddha Shinde <shraddha.shinde@seagate.com>
-*/
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
 #include "ut_efs_helper.h"
 
 /**

--- a/efs/src/test/ut/ut_efs_dir_ops.c
+++ b/efs/src/test/ut/ut_efs_dir_ops.c
@@ -2,15 +2,21 @@
  * Filename: ut_efs_dir_ops.c
  * Description: Implementation tests for directory operartions
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Shraddha Shinde <shraddha.shinde@seagate.com>
-*/
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
 #include "ut_efs_helper.h"
 #define DIR_NAME_LEN_MAX 255
 #define DIR_ENV_FROM_STATE(__state) (*((struct ut_dir_env **)__state))

--- a/efs/src/test/ut/ut_efs_endpoint.h
+++ b/efs/src/test/ut/ut_efs_endpoint.h
@@ -2,14 +2,19 @@
  * Filename: efs_export.h
  * Description:  Declararions of functions used to test efs_export
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Jatinder Kumar <jatinder.kumar@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef TEST_EFS_FS_H

--- a/efs/src/test/ut/ut_efs_endpoint_dummy.c
+++ b/efs/src/test/ut/ut_efs_endpoint_dummy.c
@@ -2,14 +2,19 @@
   Filename: ut_efs_endpoint_ops_dummy.c
  * Description: This file implements intialization of dummy endpoint operation.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Jatinder Kumar <jatinder.kumar@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include "ut_efs_endpoint_dummy.h"

--- a/efs/src/test/ut/ut_efs_endpoint_dummy.h
+++ b/efs/src/test/ut/ut_efs_endpoint_dummy.h
@@ -2,14 +2,19 @@
  * Filename: efs_export.h
  * Description:  Declararions of functions used to test efs_export
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Jatinder Kumar <jatinder.kumar@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include "efs.h"

--- a/efs/src/test/ut/ut_efs_endpoint_ops.c
+++ b/efs/src/test/ut/ut_efs_endpoint_ops.c
@@ -2,14 +2,19 @@
   Filename: efs_endpoint.c
  * Description: implementation tests for efs_endpoint.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Jatinder Kumar <jatinder.kumar@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include "ut_efs_endpoint_dummy.h"

--- a/efs/src/test/ut/ut_efs_file_ops.c
+++ b/efs/src/test/ut/ut_efs_file_ops.c
@@ -2,15 +2,21 @@
  * Filename: ut_efs_file_ops.c
  * Description: Implementation tests for file creation
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Shraddha Shinde <shraddha.shinde@seagate.com>
-*/
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
 #include "ut_efs_helper.h"
 
 /**

--- a/efs/src/test/ut/ut_efs_fs_ops.c
+++ b/efs/src/test/ut/ut_efs_fs_ops.c
@@ -1,15 +1,20 @@
 /*
-  Filename: ut_efs_fs.c
- * Description: mplementation tests for efs_fs
+ * Filename: ut_efs_fs.c
+ * Description: implementation tests for efs_fs
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Jatinder Kumar <jatinder.kumar@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include "ut_efs_helper.h"

--- a/efs/src/test/ut/ut_efs_helper.c
+++ b/efs/src/test/ut/ut_efs_helper.c
@@ -2,14 +2,19 @@
  * Filename: ut_efs_helper.c
  * Description: Functions for fs_open and fs_close required for test
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Shraddha Shinde <shraddha.shinde@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include "ut_efs_helper.h"

--- a/efs/src/test/ut/ut_efs_helper.h
+++ b/efs/src/test/ut/ut_efs_helper.h
@@ -2,14 +2,19 @@
  * Filename: efs_fs.h
  * Description:  Declararions of functions used to test efs_fs
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Jatinder Kumar <jatinder.kumar@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef TEST_EFS_FS_H

--- a/efs/src/test/ut/ut_efs_io_bug_ops.c
+++ b/efs/src/test/ut/ut_efs_io_bug_ops.c
@@ -2,15 +2,20 @@
  * Filename: ut_efs_io_bug_ops.c
  * Description: Implementation tests for read and write bugs
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Shraddha Shinde <shraddha.shinde@seagate.com>
-*/
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 #include "ut_efs_helper.h"
 #define BLOCK_SIZE 4096

--- a/efs/src/test/ut/ut_efs_io_ops.c
+++ b/efs/src/test/ut/ut_efs_io_ops.c
@@ -2,15 +2,20 @@
  * Filename: ut_efs_io_ops.c
  * Description: Implementation tests for read and write
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Shraddha Shinde <shraddha.shinde@seagate.com>
-*/
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 #include "ut_efs_helper.h"
 #define BLOCK_SIZE 4096

--- a/efs/src/test/ut/ut_efs_link_ops.c
+++ b/efs/src/test/ut/ut_efs_link_ops.c
@@ -2,15 +2,21 @@
  * Filename: ut_efs_link_ops.c
  * Description: Implementation tests for links
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Shraddha Shinde <shraddha.shinde@seagate.com>
-*/
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
 #include "ut_efs_helper.h"
 #define LINK_ENV_FROM_STATE(__state) (*((struct ut_link_env **)__state))
 

--- a/efs/src/test/ut/ut_efs_management.c
+++ b/efs/src/test/ut/ut_efs_management.c
@@ -1,16 +1,20 @@
-/**
+/*
  * Filename: test-control.c
  * Description: Control Tester.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <stdio.h>

--- a/efs/src/test/ut/ut_efs_rename_ops.c
+++ b/efs/src/test/ut/ut_efs_rename_ops.c
@@ -2,15 +2,21 @@
  * Filename: ut_efs_rename_ops.c
  * Description: Implementation tests for rename
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Shraddha Shinde <shraddha.shinde@seagate.com>
-*/
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
 #include "ut_efs_helper.h"
 #define RENAME_ENV_FROM_STATE(__state) (*((struct ut_rename_env **)__state))
 

--- a/efs/src/test/ut/ut_efs_xattr_dir_ops.c
+++ b/efs/src/test/ut/ut_efs_xattr_dir_ops.c
@@ -2,15 +2,21 @@
  * Filename: efs_xattr_dir_ops.c
  * Description: Tests for  xattr operations on directories.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Subhash Arya <subhash.arya@seagate.com>
-*/
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
 #include "efs_xattr_ops.h"
 
 /**

--- a/efs/src/test/ut/ut_efs_xattr_file_ops.c
+++ b/efs/src/test/ut/ut_efs_xattr_file_ops.c
@@ -2,15 +2,21 @@
  * Filename: efs_xattr_ops.c
  * Description: Implementation tests for xattr
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
-} *
- * Author: Shraddha Shinde <shraddha.shinde@seagate.com>
-*/
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
 #include "efs_xattr_ops.h"
 
 /**

--- a/efs/src/test/ut/ut_efs_xattr_ops.c
+++ b/efs/src/test/ut/ut_efs_xattr_ops.c
@@ -2,15 +2,20 @@
  * Filename: efs_xattr_ops.c
  * Description: Implementation tests for xattr
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Shraddha Shinde <shraddha.shinde@seagate.com>
-*/
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 #include "efs_xattr_ops.h"
 #include <sys/xattr.h> /* XATTR_CREATE */

--- a/experiments/getattr_profiling.c
+++ b/experiments/getattr_profiling.c
@@ -2,14 +2,19 @@
  * Filename: getattr_profiling.c
  * Description: Implementation tests for file attributes
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Atita Shirwaikar <atita.shirwaikar@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 /* This file has the implementation for the following experiment.

--- a/experiments/readdir_profiling.c
+++ b/experiments/readdir_profiling.c
@@ -2,15 +2,20 @@
  * Filename: readdir_profiling.c
  * Description: Implementation tests for directory operartions
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Atita Shirwaikar <atita.shirwaikar@seagate.com>
-*/
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 /* This code has the implementation for the following experiment.
  * - Create files

--- a/experiments/xattr/approach1.c
+++ b/experiments/xattr/approach1.c
@@ -1,21 +1,21 @@
-/* -*- C -*- */
 /*
- * COPYRIGHT 2014 SEAGATE LLC
+ * Filename:         approach1.c
+ * Description:
  *
- * THIS DRAWING/DOCUMENT, ITS SPECIFICATIONS, AND THE DATA CONTAINED
- * HEREIN, ARE THE EXCLUSIVE PROPERTY OF SEAGATE LLC,
- * ISSUED IN STRICT CONFIDENCE AND SHALL NOT, WITHOUT
- * THE PRIOR WRITTEN PERMISSION OF SEAGATE TECHNOLOGY LIMITED,
- * BE REPRODUCED, COPIED, OR DISCLOSED TO A THIRD PARTY, OR
- * USED FOR ANY PURPOSE WHATSOEVER, OR STORED IN A RETRIEVAL SYSTEM
- * EXCEPT AS ALLOWED BY THE TERMS OF SEAGATE LICENSES AND AGREEMENTS.
- *
- * YOU SHOULD HAVE RECEIVED A COPY OF SEAGATE'S LICENSE ALONG WITH
- * THIS RELEASE. IF NOT PLEASE CONTACT A SEAGATE REPRESENTATIVE
- * http://www.xyratex.com/contact
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
  */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/experiments/xattr/approach1_async.c
+++ b/experiments/xattr/approach1_async.c
@@ -1,19 +1,20 @@
-/* -*- C -*- */
 /*
- * COPYRIGHT 2014 SEAGATE LLC
+ * Filename:         approach1_async.c
+ * Description:
  *
- * THIS DRAWING/DOCUMENT, ITS SPECIFICATIONS, AND THE DATA CONTAINED
- * HEREIN, ARE THE EXCLUSIVE PROPERTY OF SEAGATE LLC,
- * ISSUED IN STRICT CONFIDENCE AND SHALL NOT, WITHOUT
- * THE PRIOR WRITTEN PERMISSION OF SEAGATE TECHNOLOGY LIMITED,
- * BE REPRODUCED, COPIED, OR DISCLOSED TO A THIRD PARTY, OR
- * USED FOR ANY PURPOSE WHATSOEVER, OR STORED IN A RETRIEVAL SYSTEM
- * EXCEPT AS ALLOWED BY THE TERMS OF SEAGATE LICENSES AND AGREEMENTS.
- *
- * YOU SHOULD HAVE RECEIVED A COPY OF SEAGATE'S LICENSE ALONG WITH
- * THIS RELEASE. IF NOT PLEASE CONTACT A SEAGATE REPRESENTATIVE
- * http://www.xyratex.com/contact
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <stdio.h>

--- a/experiments/xattr/approach2.c
+++ b/experiments/xattr/approach2.c
@@ -1,19 +1,20 @@
-/* -*- C -*- */
 /*
- * COPYRIGHT 2014 SEAGATE LLC
+ * Filename:         approach2.c
+ * Description:
  *
- * THIS DRAWING/DOCUMENT, ITS SPECIFICATIONS, AND THE DATA CONTAINED
- * HEREIN, ARE THE EXCLUSIVE PROPERTY OF SEAGATE LLC,
- * ISSUED IN STRICT CONFIDENCE AND SHALL NOT, WITHOUT
- * THE PRIOR WRITTEN PERMISSION OF SEAGATE TECHNOLOGY LIMITED,
- * BE REPRODUCED, COPIED, OR DISCLOSED TO A THIRD PARTY, OR
- * USED FOR ANY PURPOSE WHATSOEVER, OR STORED IN A RETRIEVAL SYSTEM
- * EXCEPT AS ALLOWED BY THE TERMS OF SEAGATE LICENSES AND AGREEMENTS.
- *
- * YOU SHOULD HAVE RECEIVED A COPY OF SEAGATE'S LICENSE ALONG WITH
- * THIS RELEASE. IF NOT PLEASE CONTACT A SEAGATE REPRESENTATIVE
- * http://www.xyratex.com/contact
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <stdio.h>

--- a/nsal/src/common/mero/m0common.c
+++ b/nsal/src/common/mero/m0common.c
@@ -1,16 +1,23 @@
 /*
  * Filename:         m0common.c
  * Description:      Contains mero helpers
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- @todo Move this code to utils/src/eos/helpers.c file, after
+/* @todo Move this code to utils/src/eos/helpers.c file, after
  iterators are generalized. (EOS-4351)
 */
 #include <stdlib.h>

--- a/nsal/src/common/mero/m0common.h
+++ b/nsal/src/common/mero/m0common.h
@@ -1,16 +1,23 @@
 /*
  * Filename:         m0common.h
  * Description:      Contains implementation mero helpers
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- @todo Move this code to utils/src/eos/helpers.c file, after
+/* @todo Move this code to utils/src/eos/helpers.c file, after
  iterators are generalized. (EOS-4351)
 */
 

--- a/nsal/src/include/internal/eos/eos_kvstore.h
+++ b/nsal/src/include/internal/eos/eos_kvstore.h
@@ -2,17 +2,25 @@
  * Filename:         eos_kvstore.h
  * Description:      Provides EOS specific implementation of
  * 		     KVStore module of NSAL.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- This EOS specific implementation is based on m0_clovis's index entity.
-*/
+/*
+ * This EOS specific implementation is based on m0_clovis's index entity.
+ */
 
 #ifndef _EOS_KVSTORE_H
 #define _EOS_KVSTORE_H

--- a/nsal/src/include/internal/nsal_common.h
+++ b/nsal/src/include/internal/nsal_common.h
@@ -2,14 +2,19 @@
  * Filename: nsal_common.h
  * Description: tenant - nsal common data structures
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Jatinder Kumar <jatinder.kumar@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef _NSAL_COMMON_H_

--- a/nsal/src/include/internal/redis/redis_kvstore.h
+++ b/nsal/src/include/internal/redis/redis_kvstore.h
@@ -1,18 +1,22 @@
 /*
  * Filename:         redis_kvstore.h
- * Description:      Provides EOS specific implementation of
+ * Description:      Provides REDIS specific implementation of
  *                  KVStore module of NSAL.
-
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- This REDIS specific implementation for kvstore.
-*/
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 #include "kvstore.h"
 #include <common/helpers.h>

--- a/nsal/src/include/kvnode.h
+++ b/nsal/src/include/kvnode.h
@@ -1,18 +1,22 @@
-/******************************************************************************/
 /*
  * Filename: kvnode.h
  * Description: kvnode - Data types and declarations for kvnode - component of
  *                       kvtree.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
-/******************************************************************************/
 
 #ifndef _KVNODE_H_
 #define _KVNODE_H_

--- a/nsal/src/include/kvstore.h
+++ b/nsal/src/include/kvstore.h
@@ -1,16 +1,23 @@
 /*
  * Filename:         kvstore.h
  * Description:      Key Value Store module of NSAL
-
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- This file contains KVStore framework infrastructure.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+ 
+ /* This file contains KVStore framework infrastructure.
  There are currently 2 users of this infrastructure,
 	1. eos_kvs
 	2. redis

--- a/nsal/src/include/kvtree.h
+++ b/nsal/src/include/kvtree.h
@@ -2,13 +2,19 @@
  * Filename: kvtree.h
  * Description: kvtree - Data types and declarations for NSAL kvtree.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef _KVTREE_H_

--- a/nsal/src/include/md_common.h
+++ b/nsal/src/include/md_common.h
@@ -2,14 +2,19 @@
  * Filename: md_common.h
  * Description: Metadata - Data types and declarations for common metadata api.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Subhash Arya <subhash.arya@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef _MD_COMMON_H

--- a/nsal/src/include/md_xattr.h
+++ b/nsal/src/include/md_xattr.h
@@ -2,14 +2,19 @@
  * Filename: md_xattr.h
  * Description: xattr - Data types and declarations for  NSAL xattr api.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Subhash Arya <subhash.arya@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef MD_XATTR__H

--- a/nsal/src/include/namespace.h
+++ b/nsal/src/include/namespace.h
@@ -2,14 +2,19 @@
  * Filename: namespace.h
  * Description: namespace - Data types and declarations for NSAL namespace.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Jatinder Kumar <jatinder.kumar@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef _NAMESPACE_H_

--- a/nsal/src/include/nsal.h
+++ b/nsal/src/include/nsal.h
@@ -2,13 +2,19 @@
  * Filename: nsal.h
  * Description: Data types and declarations for NSAL.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef _NSAL_H_

--- a/nsal/src/include/tenant.h
+++ b/nsal/src/include/tenant.h
@@ -2,14 +2,19 @@
  * Filename: tenant.h
  * Description: tenant - Data types and declarations for NSAL tenant.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Jatinder Kumar <jatinder.kumar@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef _TENANT_H_

--- a/nsal/src/kvstore/kvstore_base.c
+++ b/nsal/src/kvstore/kvstore_base.c
@@ -2,17 +2,21 @@
  * Filename:         kvstore_base.c
  * Description:      Contains implementation of basic KVStore
  * 		     framework APIs.
-
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- Contains implementation of basic kvstore framework APIs.
-*/
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 #include "kvstore.h"
 #include <assert.h>

--- a/nsal/src/kvstore/plugins/eos/eos_kvstore.c
+++ b/nsal/src/kvstore/plugins/eos/eos_kvstore.c
@@ -1,18 +1,27 @@
 /*
- * Filename:         eos_kvstore.c
- * Description:      Implementation of EOS KVStore.
+ * Filename: eos_kvstore.c
+ * Description: Implementation of EOS KVStore.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- This file contains APIs which implement NSAL's KVStore framework,
- on top of eos clovis index APIs.
-*/
+/*
+ * This file contains APIs which implement NSAL's KVStore framework,
+ * on top of eos clovis index APIs.
+ */
+ 
 #include "internal/eos/eos_kvstore.h"
 #include <eos/helpers.h>
 

--- a/nsal/src/kvstore/plugins/redis/redis_kvstore.c
+++ b/nsal/src/kvstore/plugins/redis/redis_kvstore.c
@@ -1,18 +1,26 @@
 /*
  * Filename: redis_kvstore.c
  * Description:      Implementation of Redis KVStore.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- This file contains APIs which implement NSAL's KVStore framework,
- on top of Redis.
-*/
+/*
+ * This file contains APIs which implement NSAL's KVStore framework,
+ * on top of Redis.
+ */
 
 #include "redis/redis_kvstore.h"
 #include <hiredis/hiredis.h>

--- a/nsal/src/kvtree/kvnode.c
+++ b/nsal/src/kvtree/kvnode.c
@@ -1,3 +1,22 @@
+/*
+ * Filename:         kvnode.c
+ * Description:
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
 #include "kvtree.h"
 #include "kvnode.h"
 #include "kvnode_internal.h"

--- a/nsal/src/kvtree/kvnode_internal.h
+++ b/nsal/src/kvtree/kvnode_internal.h
@@ -1,16 +1,22 @@
 /*
  * Filename:         kvnode_internal.h
  * Description:      kvnode - Data types and declarations for kvnode -
-                     component of kvtree.
-
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-*/
+ *                   component of kvtree.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 #ifndef _KVNODE_INTERNAL_H
 #define _KVNODE_INTERNAL_H

--- a/nsal/src/kvtree/kvtree.c
+++ b/nsal/src/kvtree/kvtree.c
@@ -1,3 +1,22 @@
+/*
+ * Filename:         kvtree.c
+ * Description:
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
 #include <errno.h> /* error no */
 #include "kvtree.h"
 #include "kvnode.h"

--- a/nsal/src/metadata/md_common.c
+++ b/nsal/src/metadata/md_common.c
@@ -2,15 +2,19 @@
  * Filename: md_common.c
  * Description: Metadata - Implementation of common apis used by NSAL.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
- *
- * Author: Subhash Arya <subhash.arya@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <md_common.h>

--- a/nsal/src/metadata/md_xattrs.c
+++ b/nsal/src/metadata/md_xattrs.c
@@ -2,14 +2,19 @@
  * Filename: md_xattrs.c
  * Description: Metadata - Implementation of Extended Attributes
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Subhash Arya <subhash.arya@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <stdio.h>

--- a/nsal/src/namespace/ns.c
+++ b/nsal/src/namespace/ns.c
@@ -2,14 +2,19 @@
  * Filename: ns.c
  * Description: Metadata - Implementation of Namesapce API.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- *  Author: Jatinder Kumar <jatinder.kumar@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <errno.h> /* error no */

--- a/nsal/src/nsal/nsal.c
+++ b/nsal/src/nsal/nsal.c
@@ -2,13 +2,19 @@
  * Filename: nsal.c
  * Description: Implementation of NSAL.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <errno.h> /* errno */

--- a/nsal/src/tenant/tenant.c
+++ b/nsal/src/tenant/tenant.c
@@ -2,14 +2,19 @@
  * Filename: tenant.c
  * Description: Metadata - Implementation of Tenant API.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- *  Author: Jatinder Kumar <jatinder.kumar@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <errno.h> /* error no */

--- a/nsal/src/test/test_tenant.c
+++ b/nsal/src/test/test_tenant.c
@@ -2,14 +2,19 @@
  * Filename: test_tenant.c
  * Description: Implementation tests for tenant.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Jatinder Kumar <jatinder.kumar@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <errno.h>

--- a/nsal/src/test/ut/ut_nsal_iter_ops.c
+++ b/nsal/src/test/ut/ut_nsal_iter_ops.c
@@ -1,3 +1,22 @@
+/*
+ * Filename:         ut_nsal_iter_ops.c
+ * Description:
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+ 
 #include <stdio.h>
 #include <stdlib.h>
 #include <ini_config.h>

--- a/nsal/src/test/ut/ut_nsal_kvtree_ops.c
+++ b/nsal/src/test/ut/ut_nsal_kvtree_ops.c
@@ -2,14 +2,19 @@
  * Filename: ut_nsal_kvtree_ops.c 
  * Description: Unit tests for kvtree.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Shreya Karmakar <shreya.karmakar@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include "kvtree.h"

--- a/nsal/src/test/ut/ut_nsal_ns.h
+++ b/nsal/src/test/ut/ut_nsal_ns.h
@@ -2,14 +2,19 @@
  * Filename: ut_nsal_ns.h
  * Description: Declararions of functions used to test nsal
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Jatinder Kumar <jatinder.kumar@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef TEST_NSAL_H

--- a/nsal/src/test/ut/ut_nsal_ns_ops.c
+++ b/nsal/src/test/ut/ut_nsal_ns_ops.c
@@ -2,14 +2,19 @@
  * Filename: ut_nsal_ns_ops.c
  * Description: Implementation tests for namespace.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2020, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Jatinder Kumar <jatinder.kumar@seagate.com>
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <errno.h>

--- a/utils/src/common/str.c
+++ b/utils/src/common/str.c
@@ -2,14 +2,19 @@
  * Filename:         str.c
  * Description:      string utilities
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <errno.h>

--- a/utils/src/common/utils.c
+++ b/utils/src/common/utils.c
@@ -2,14 +2,19 @@
  * Filename:         utils.c
  * Description:      common utilities
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <string.h>

--- a/utils/src/eos/m0common.c
+++ b/utils/src/eos/m0common.c
@@ -1,19 +1,27 @@
 /*
  * Filename:         m0common.c
  * Description:      Contains setup variables and functions of mero
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- Contains all eos objects needed by m0kvs.c & m0store.c &
- implementation of init/fini APIs.
-*/
-
+/*
+ * Contains all eos objects needed by m0kvs.c & m0store.c &
+ * implementation of init/fini APIs.
+ */
+ 
 #include "m0common.h"
 #include <common/log.h>
 #include <debug.h> /* dassert */

--- a/utils/src/eos/m0common.h
+++ b/utils/src/eos/m0common.h
@@ -1,17 +1,22 @@
 /*
  * Filename:         m0common.h
  * Description:      Contains declarations needed by m0kvs.c & m0store.c
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- Contains declarations needed by m0kvs.c & m0store.c
-*/
 #ifndef _M0COMMON_H
 #define _M0COMMON_H
 

--- a/utils/src/eos/m0kvs.c
+++ b/utils/src/eos/m0kvs.c
@@ -1,17 +1,22 @@
 /*
  * Filename:         m0kvs.c
  * Description:      Contains mero related kv operations
-
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- Contains mero related kv operations which use clovis index.
-*/
+ *                   which use clovis index.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 #include "m0common.h"
 #include "common/log.h"

--- a/utils/src/eos/m0store.c
+++ b/utils/src/eos/m0store.c
@@ -1,17 +1,22 @@
 /*
  * Filename:         m0store.c
  * Description:      Contains mero related IO operations
-
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- Contains mero related IO operations which use clovis objects.
-*/
+ *                   which use clovis objects.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 #include "m0common.h"
 #include "common/log.h" /* log_* */

--- a/utils/src/fault/fault-points.c
+++ b/utils/src/fault/fault-points.c
@@ -1,16 +1,20 @@
-/**
+/*
  * Filename: fault-points.c
  * Description: Internal definations for fault framework.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- * 
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
  
 #include <stdlib.h>

--- a/utils/src/fault/fault.c
+++ b/utils/src/fault/fault.c
@@ -1,16 +1,20 @@
-/**
+/*
  * Filename: fault.c
  * Description: Fault injection Framework.
- * 
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- * 
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
  *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <assert.h>

--- a/utils/src/include/common.h
+++ b/utils/src/include/common.h
@@ -1,16 +1,20 @@
-/**
+/*
  * Filename: common.h
  * Description: Headers for utils framework.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef _UTILS_COMMON_H

--- a/utils/src/include/common/helpers.h
+++ b/utils/src/include/common/helpers.h
@@ -1,17 +1,21 @@
 /*
  * Filename:         helpers.h
  * Description:      Helper macros in case of errors
-
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
-  Helper return code macros
-*/
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 #ifndef _COMMON_HELPERS_H
 #define _COMMON_HELPERS_H

--- a/utils/src/include/common/log.h
+++ b/utils/src/include/common/log.h
@@ -1,16 +1,20 @@
 /*
  * Filename:         log.h
- * Description:      Basic log functions
+ * Description:      Contains implementation of basic log APIs
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
- *
- * Contains implementation of basic log APIs.
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef _LOG_H

--- a/utils/src/include/debug.h
+++ b/utils/src/include/debug.h
@@ -2,14 +2,19 @@
  * Filename:         debug.h
  * Description:      Debug related configuration
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef _DEBUG_H

--- a/utils/src/include/eos/helpers.h
+++ b/utils/src/include/eos/helpers.h
@@ -1,18 +1,22 @@
 /*
  * Filename:         helpers.h
  * Description:      Contains declarations of eos functionality needed
- * 		     by nsal, efs, dsal
-
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
-
- Contains declarations of eos funnctionality needed by nsal, efs, dsal.
-*/
+ *                   by nsal, efs, dsal
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
 
 #ifndef _HELPERS_H
 #define _HELPERS_H

--- a/utils/src/include/fault.h
+++ b/utils/src/include/fault.h
@@ -1,16 +1,20 @@
-/**
+/*
  * Filename: fault.h
  * Description: Headers for fault framework.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- * 
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef _IFAULT_H

--- a/utils/src/include/internal/fault-points.h
+++ b/utils/src/include/internal/fault-points.h
@@ -1,16 +1,20 @@
-/**
+/*
  * Filename: fault-internal.h
  * Description: Internal Headers for fault framework.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- * 
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef _IFAULT_INTERNAL_H

--- a/utils/src/include/internal/management-internal.h
+++ b/utils/src/include/internal/management-internal.h
@@ -1,17 +1,20 @@
-/**
+/*
  * Filename: management-internal.h
- *
  * Description: Management internal data-types and function proto-types.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef _MANAGEMENT_INTERNAL_H_

--- a/utils/src/include/management.h
+++ b/utils/src/include/management.h
@@ -1,20 +1,25 @@
-/**
+/*
  * Filename: management.h
- *
  * Description: Management Module: REST Framewrok for system component management.
  * The management framework provies api's to create the HTTP rest server.
  * We can register "controllers" to it which supports api's for management.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
- *
- * HOW TO USE?
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
+/* HOW TO USE?
  *
  * Management framework provides api's to create a RESTFULL HTTP server.
  * And the can be used to overall management of system. We can manage the various

--- a/utils/src/include/object.h
+++ b/utils/src/include/object.h
@@ -1,16 +1,20 @@
-/**
+/*
  * Filename: object.h
  * Description: Contains definitions of obj_id_t
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Conatins definitions of obj_id_t
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef _UTILS_OBJECT_H

--- a/utils/src/include/operation.h
+++ b/utils/src/include/operation.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Filename:	operation.h
  * Description:	This module defines Operation API.
  *
@@ -14,8 +14,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  * For any questions about this software or licensing,
- * please email opensource@seagate.com or cortx-questions@seagate.com.*
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
+
 #ifndef OPERATION_H_
 #define OPERATION_H_
 /******************************************************************************/

--- a/utils/src/include/perf/perf-counters.h
+++ b/utils/src/include/perf/perf-counters.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Filename:	perf-counters.h
  * Description:	This module defines performance counters and helpers.
  *
@@ -14,8 +14,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  * For any questions about this software or licensing,
- * please email opensource@seagate.com or cortx-questions@seagate.com.*
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
+
 #ifndef PERF_COUNTERS_H_
 #define PERF_COUNTERS_H_
 /******************************************************************************/

--- a/utils/src/include/perf/tsdb-addb.h
+++ b/utils/src/include/perf/tsdb-addb.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Filename:	tsdb-addb.h
  * Description:	This module defines ADDB-based interfaces for TSDB.
  *
@@ -14,8 +14,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  * For any questions about this software or licensing,
- * please email opensource@seagate.com or cortx-questions@seagate.com.*
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
+
 #ifndef TSDB_ADDB_H_
 #define TSDB_ADDB_H_
 /******************************************************************************/

--- a/utils/src/include/perf/tsdb-dummy.h
+++ b/utils/src/include/perf/tsdb-dummy.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Filename:	tsdb-dummy.h
  * Description:	This module defines a noop implementation of TSDB backend.
  *
@@ -14,8 +14,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  * For any questions about this software or licensing,
- * please email opensource@seagate.com or cortx-questions@seagate.com.*
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
+
 #ifndef TSDB_DUMMY_H_
 #define TSDB_DUMMY_H_
 /******************************************************************************/

--- a/utils/src/include/perf/tsdb-printf.h
+++ b/utils/src/include/perf/tsdb-printf.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Filename:	tsdb-printf.h
  * Description:	This module defines a dummy printf-based TSDB engine.
  *
@@ -14,11 +14,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  * For any questions about this software or licensing,
- * please email opensource@seagate.com or cortx-questions@seagate.com.*
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
+
 /* This module can be used only for debugging of public TSDB API. It has
  * zero meaning for real-life scenarios.
  */
+
 #ifndef TSDB_PRINTF_H_
 #define TSDB_PRINTF_H_
 /******************************************************************************/

--- a/utils/src/include/perf/tsdb.h
+++ b/utils/src/include/perf/tsdb.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Filename:	tsdb.h
  * Description:	This module defines TSDB interfaces.
  *
@@ -14,8 +14,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  * For any questions about this software or licensing,
- * please email opensource@seagate.com or cortx-questions@seagate.com.*
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
+
 #ifndef TSDB_H_
 #define TSDB_H_
 /******************************************************************************/

--- a/utils/src/include/str.h
+++ b/utils/src/include/str.h
@@ -2,14 +2,19 @@
  * Filename:         utils.h
  * Description:      common structures
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef _EOS_STR_H_

--- a/utils/src/include/ut.h
+++ b/utils/src/include/ut.h
@@ -1,3 +1,22 @@
+/*
+ * Filename: ut.h
+ * Description: Headers for ut framework.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
 #include <stdio.h>
 #include <setjmp.h> /* jmp_buf */
 #include <cmocka.h> /* cmocka */

--- a/utils/src/include/utils.h
+++ b/utils/src/include/utils.h
@@ -2,14 +2,19 @@
  * Filename:         utils.h
  * Description:      common structures
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #ifndef _EOS_UTILS_H_

--- a/utils/src/log/log.c
+++ b/utils/src/log/log.c
@@ -1,16 +1,20 @@
 /*
  * Filename:         log.c
- * Description:      Basic log functions
+ * Description:      Contains implementation of basic log APIs.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation,
- * distribution or disclosure of this code, for any reason, not expressly
- * authorized is prohibited. All other rights are expressly reserved by
- * Seagate Technology, LLC.
- *
- * Contains implementation of basic log APIs.
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <stdio.h>

--- a/utils/src/management/controller.c
+++ b/utils/src/management/controller.c
@@ -1,18 +1,22 @@
-/**
+/*
  * Filename: controller.c
  * Description: Basic controller API.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
-
+ 
 #include "management.h"
 #include "internal/management-internal.h"
 #include "debug.h" /* dassert() */

--- a/utils/src/management/http.c
+++ b/utils/src/management/http.c
@@ -1,18 +1,22 @@
-/**
+/*
  * Filename: http.c
  * Description: HTTP APIs.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
-
+ 
 #include "management.h"
 #include "internal/management-internal.h"
 #include "debug.h" /* dassert() */

--- a/utils/src/management/params.c
+++ b/utils/src/management/params.c
@@ -1,17 +1,22 @@
-/**
+/*
  * Filename: params.c
  * Description: Server params.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
+ 
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/utils/src/management/request-handler.c
+++ b/utils/src/management/request-handler.c
@@ -1,16 +1,20 @@
-/**
+/*
  * Filename: request-handler.c
  * Description: Control request handler.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <json/json.h> /* for json_object */

--- a/utils/src/management/server.c
+++ b/utils/src/management/server.c
@@ -1,16 +1,20 @@
-/**
+/*
  * Filename: control.c
  * Description: APIs for main.c.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <sys/queue.h> /* LIST_* */

--- a/utils/src/management/utils.c
+++ b/utils/src/management/utils.c
@@ -1,18 +1,22 @@
-/**
+/*
  * Filename: utils.c
  * Description: General purpose utility functions.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
-
+ 
 #include <errno.h>
 #include "management.h"
 #include "internal/management-internal.h"

--- a/utils/src/test/fault/fault-test.c
+++ b/utils/src/test/fault/fault-test.c
@@ -1,16 +1,20 @@
-/**
+/*
  * Filename: fault-test.c
  * Description: Test script for fault framework.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- * 
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <stdio.h>

--- a/utils/src/test/management/management-test.c
+++ b/utils/src/test/management/management-test.c
@@ -1,16 +1,20 @@
-/**
+/*
  * Filename: management-test.c
  * Description: Main control.
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
- *
- * Author: Yogesh Lahane <yogesh.lahane@seagate.com>
- *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 #include <stdio.h>

--- a/utils/src/test/perf/perf-manual-test.c
+++ b/utils/src/test/perf/perf-manual-test.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Filename:    perf-manual-test.c
  * Description: This file implements several test cases for manual testing of
  *		performance-related interfaces.
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  * For any questions about this software or licensing,
- * please email opensource@seagate.com or cortx-questions@seagate.com.*
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
 /* Print tsdb output into stdout instead of using ADDB. */

--- a/utils/src/tsdb/tsdb.c
+++ b/utils/src/tsdb/tsdb.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Filename:	tsdb.c
  * Description:	This module implements TSDB frontend interface.
  *
@@ -14,8 +14,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  * For any questions about this software or licensing,
- * please email opensource@seagate.com or cortx-questions@seagate.com.*
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
+ 
 #include "perf/tsdb.h"
 
 /** TSDB state */

--- a/utils/src/ut/ut.c
+++ b/utils/src/ut/ut.c
@@ -2,14 +2,20 @@
  * Filename: ut.h
  * Description: Unit Test Framework
  *
- * Do NOT modify or remove this copyright and confidentiality notice!
- * Copyright (c) 2019, Seagate Technology, LLC.
- * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
- * Portions are also trade secret. Any use, duplication, derivation, distribution
- * or disclosure of this code, for any reason, not expressly authorized is
- * prohibited. All other rights are expressly reserved by Seagate Technology, LLC.
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
-/******************************************************************************/
 
 #include <debug.h>
 #include "ut.h"


### PR DESCRIPTION
**Problem Statement**
EOS-11661: EOS-NFS: Update copyright message in CORTX-POSIX directory

**Problem Description**
Update copyright message in CORTX-POSIX directory

**Solution Overview**
Updated the copyright info in all the .c and .h files in CORTX-POSIX repository
as discussed, skipped build scripts and cmake files.
 
**Unit Test Cases**

[root@ssc-vm-c-0338 cortx-posix]# ./scripts/test.sh

NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

EFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 12
Tests passed = 12
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

[root@ssc-vm-c-0338 cortx-posix]#