### PR TITLE
EOS-12003: UT enhancement to create indexes

### DIFF
--- a/scripts/motr_lib_init.sh
+++ b/scripts/motr_lib_init.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+# Index info
+PROFILE='<0x7000000000000001:0>'
+PROC_FID='<0x7200000000000000:0>'
+LOC_EXPORT_ID='@tcp:12345:44:301'
+HA_EXPORT_ID='@tcp:12345:45:1'
+KVS_GLOBAL_FID='<0x780000000000000b:1>'
+KVS_NS_META_FID='<0x780000000000000b:2>'
+INDEX_DIR=/tmp
+CORTXFS_CONF=/etc/cortx/cortxfs.conf
+CORTXFS_CONF_BAK=${CORTXFS_CONF}.$$
+
+die() {
+	echo "Error: $*"
+	exit 1
+}
+
+prepare_cortx_fs_conf () {
+	# Backup cortxfs.conf file
+	[ ! -e $CORTXFS_CONF_BAK ] && cp $CORTXFS_CONF $CORTXFS_CONF_BAK
+
+	# Modify cortxfs.conf
+	tmp_var=$(sed -n '/\[log\]/ {=;q}' $CORTXFS_CONF)
+	[ $? -ne 0 ] && die "Failed to access cortxfs.conf file"
+
+	sed -i "$tmp_var,\$d" $CORTXFS_CONF
+	[ $? -ne 0 ] && die "Failed to edit cortxfs.conf file"
+
+	cat >> $CORTXFS_CONF << EOM
+[log]
+path = /var/log/cortx/fs/cortxfs.log
+level = LEVEL_INFO
+
+[kvstore]
+type = cortx
+ns_meta_fid = $KVS_NS_META_FID
+
+[dstore]
+type = cortx
+
+[motr]
+local_addr = $ip_add$LOC_EXPORT_ID
+ha_addr = $ip_add$HA_EXPORT_ID
+profile = $PROFILE
+proc_fid = $PROC_FID
+index_dir = $INDEX_DIR
+kvs_fid = $KVS_GLOBAL_FID
+EOM
+	[ $? -ne 0 ] && die "Failed to configure cortxfs.conf"
+
+	echo "Configuration Completed"
+}
+
+prerequisites() {
+	# Check motr-kernel
+	systemctl is-active motr-kernel > /dev/null 2>&1
+	[ $? -ne 0 ] && die "motr-kernel is not active"
+
+	# Stop nfs-ganesha service if running
+	systemctl stop nfs-ganesha
+	[ $? -ne 0 ] && die "Falied to stop nfs-ganesha service"
+
+	# Get ip address
+	v1=$(lctl list_nids 2> /dev/null)
+	ip_add=${v1::-4}
+}
+
+prepare_index() {
+	# Use existing indexes
+	[ -n "$USE_IDX" ] && return
+ 
+	# Drop indexes
+	m0clovis -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
+		-f $PROC_FID index drop "$KVS_GLOBAL_FID" > /dev/null 2>&1
+	[ $? -ne 0 ] && die "Failed to drop Global index"
+
+	m0clovis -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
+		-f $PROC_FID index drop "$KVS_NS_META_FID" > /dev/null 2>&1
+	[ $? -ne 0 ] && die "Failed to drop NS_META index"
+
+	# Create indexes
+	m0clovis -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
+		-f $PROC_FID index create "$KVS_GLOBAL_FID" > /dev/null 2>&1
+	[ $? -ne 0 ] && die "Failed to create Global index"
+
+	m0clovis -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
+		-f $PROC_FID index create "$KVS_NS_META_FID" > /dev/null 2>&1
+	[ $? -ne 0 ] && die "Failed to create NS_META index"
+
+	echo "Clean indexes prepared"
+}
+
+usage() {
+	cat <<EOM
+usage: $0 {setup|conf|idx-gen} [-h] [-e]
+Commands:
+   -h         Help
+   -e         Use existing indexes
+   setup      Configure cortxfs.conf and prepare indexes
+   conf       Configure cortxfs.conf
+   idx-gen    Prepare clean indexes
+
+Default values used for Index creation are-
+   Profile:               $PROFILE
+   Process FID:           $PROC_FID
+   Local Export Suffix:   $LOC_EXPORT_ID
+   HA Export Suffix:      $HA_EXPORT_ID
+   KVS Global FID:        $KVS_GLOBAL_FID
+   KVS NS Meta FID:       $KVS_NS_META_FID
+EOM
+	exit 1
+}
+
+#main
+
+[ $(id -u) -ne 0 ] && die "Run this script with root privileges"
+
+cmd=$1; shift 1
+
+getopt --options "he" --name motr_lib_init
+[ $? -ne 0 ] && usage
+
+while [ ! -z $1 ]; do
+	case "$1" in
+	-h ) usage;;
+	-e ) USE_IDX=1;;
+	*  ) usage;;
+	esac
+	shift 1
+done
+
+case $cmd in
+	setup   ) prerequisites; prepare_cortx_fs_conf; prepare_index;;
+	conf    ) prerequisites; prepare_cortx_fs_conf;;
+	idx-gen	) prerequisites; prepare_index;;
+	*       ) usage;;
+esac

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,6 +8,11 @@ TEST_GRP=all
 LOG_ROOT="/var/log/cortx"
 UT_LOG_ROOT="$LOG_ROOT/test/ut"
 
+die() {
+	echo "Error: $*"
+	exit 1
+}
+
 delete_logs() {
 	rm -rf $UT_LOG_ROOT
 }
@@ -21,7 +26,7 @@ execute_ut_nsal () {
 	NSAL_TEST_DIR=$BUILD_DIR/build-nsal/test/ut
 	NSAL_TEST_LIST=(ut_nsal_ns_ops ut_nsal_iter_ops ut_nsal_kvtree_ops)
 
-	[ ! -d $NSAL_TEST_DIR ] && echo "NSAL is not built" && exit 1
+	[ ! -d $NSAL_TEST_DIR ] && die "NSAL is not built"
 
 	for tests in "${NSAL_TEST_LIST[@]}"
 	do
@@ -38,11 +43,11 @@ execute_ut_efs () {
 
 	EFS_TEST_DIR=$BUILD_DIR/build-efs/test/ut
 	EFS_TEST_LIST=(ut_efs_endpoint_ops ut_efs_fs_ops ut_efs_dir_ops
-		       ut_efs_file_ops ut_efs_link_ops ut_efs_rename_ops
-		       ut_efs_attr_ops ut_efs_xattr_file_ops
-		       ut_efs_xattr_dir_ops ut_efs_io_ops)
+			ut_efs_file_ops ut_efs_link_ops ut_efs_rename_ops
+			ut_efs_attr_ops ut_efs_xattr_file_ops
+			ut_efs_xattr_dir_ops ut_efs_io_ops)
 
-	[ ! -d $EFS_TEST_DIR ] && echo "EFS is not built" && exit 1
+	[ ! -d $EFS_TEST_DIR ] && die "EFS is not built"
 
 	for tests in "${EFS_TEST_LIST[@]}"
 	do
@@ -81,31 +86,38 @@ execute_all_ut () {
 
 usage () {
 	cat <<EOM
-usage: $0 [-h] [-t <Test group>]
+usage: $0 [-h] [-e] [-t <Test group>]
 options:
 	-h	Help
+	-e	Use existing Indexes
 	-t	Test group to execute. Deafult: all groups are executed
 Test group list:
 nsal          NSAL unit tests
 efs           EFS unit tests
 EOM
-exit 1
+	exit 1
 }
 
 #main
 
-[ $(id -u) -ne 0 ] && echo "Run this script with root privileges" && exit 1
+[ $(id -u) -ne 0 ] && die "Run this script with root privileges"
 
-getopt --options "ht:" --name test
+getopt --options "het:" --name test
 
 while [ ! -z $1 ]; do
 	case "$1" in
 	-h ) usage;;
+	-e ) USE_IDX="-e";;
 	-t ) TEST_GRP=$2; shift 1;;
-	* )  usage
+	*  ) usage;;
 	esac
 	shift 1
 done
+
+# Create indexes
+cur_dir=$(dirname "$0")
+$cur_dir/motr_lib_init.sh setup $USE_IDX
+[ $? -ne 0 ] && die "Failed to initialize motr-lib"
 
 delete_logs
 execute_all_ut


### PR DESCRIPTION
**Description:**
Currently indexes are created through nfs_setup.sh sccript.
For UTs we need to run nfs_setup.sh script and then kill nfs-ganesha service.
To get rid of this work-around, index creation and corresponding changes in cortxfs.conf can be done independently through another script 
Jira: https://jts.seagate.com/browse/EOS-12003
**DoD:**
         Script creates clean clovis/ motr_lib indexes and modifies cortxfs.conf
         All UTs should pass after running script

**Fix:**
motr_lib_init.sh create indexes and configures cortxfs.conf