### PR TITLE
EOS-11992 Rename eos to cortx in source code.

### DIFF
--- a/dsal/src/dstore/dstore_base.c
+++ b/dsal/src/dstore/dstore_base.c
@@ -41,7 +41,7 @@ struct dstore_module {
 };
 
 static struct dstore_module dstore_modules[] = {
-	{ "cortx", &eos_dstore_ops },
+	{ "cortx", &cortx_dstore_ops },
 	{ NULL, NULL },
 };
 

--- a/dsal/src/dstore/dstore_internal.h
+++ b/dsal/src/dstore/dstore_internal.h
@@ -503,11 +503,11 @@ bool dstore_ops_invariant(const struct dstore_ops *ops)
 }
 
 /* FIXME: This structure does not belong here.
- * It should be moved into eos-related directory.
+ * It should be moved into cortx-related directory.
  * The consumer (dstore.c) should include this file separately.
  * It will help to remove dependencies between DSAL backends.
  */
-extern const struct dstore_ops eos_dstore_ops;
+extern const struct dstore_ops cortx_dstore_ops;
 
 
 /** A helper for DSTORE backends: initializes already-allocated

--- a/dsal/src/include/internal/eos/eos_dstore.h
+++ b/dsal/src/include/internal/eos/eos_dstore.h
@@ -22,8 +22,8 @@
  *This CORTX specific implementation is based on m0_clovis's object entity.
  */
 
-#ifndef _EOS_DSTORE_H
-#define _EOS_DSTORE_H
+#ifndef _CORTX_DSTORE_H
+#define _CORTX_DSTORE_H
 
 #include "dstore.h"
 

--- a/efs/src/include/efs_fh.h
+++ b/efs/src/include/efs_fh.h
@@ -19,7 +19,7 @@
 
 /* Low-level Design
  *
- * EFS (EOSFS) File Handle Overview.
+ * EFS File Handle Overview.
  * -----------------------------------
  *
  * EFS File Handle (efs)fh) is an in-memory object that represents
@@ -188,7 +188,7 @@ size_t efs_fh_serialized_size(void);
  * the on-wire FH handle has to be unique across the filesystems.
  * The Object:Filystem pair of FIDs is unique enough and can be easily
  * reconstructed without any additiona information and even might be used
- * outside of EOS-FS.
+ * outside of EFS.
  *
  * 2. kvsns_ino_t arguments are replaced by kvsns_fh_t. Because of that,
  * the callers should ensure to destroy the handles.

--- a/nsal/src/include/internal/eos/eos_kvstore.h
+++ b/nsal/src/include/internal/eos/eos_kvstore.h
@@ -22,34 +22,34 @@
  * This CORTX specific implementation is based on m0_clovis's index entity.
  */
 
-#ifndef _EOS_KVSTORE_H
-#define _EOS_KVSTORE_H
+#ifndef _CORTX_KVSTORE_H
+#define _CORTX_KVSTORE_H
 
 #include "kvstore.h"
 
-extern struct kvstore_ops eos_kvs_ops;
+extern struct kvstore_ops cortx_kvs_ops;
 
-int eos_kvs_alloc(void **ptr, size_t size);
-void eos_kvs_free(void *ptr);
+int cortx_kvs_alloc(void **ptr, size_t size);
+void cortx_kvs_free(void *ptr);
 
-const char *eos_kvs_get_gfid(void);
+const char *cortx_kvs_get_gfid(void);
 
-int eos_kvs_fid_from_str(const char *fid_str, kvs_idx_fid_t *out_fid);
+int cortx_kvs_fid_from_str(const char *fid_str, kvs_idx_fid_t *out_fid);
 
-int eos_kvs_get_list_size(void *ctx, char *pattern, size_t plen);
+int cortx_kvs_get_list_size(void *ctx, char *pattern, size_t plen);
 
 /** Set list of key-value pairs
  *  @param[in] kv_grp - pointer to kv_group
  *  @return 0 if successful, else return error code.
  */
-int eos_kvs_list_set(struct kvs_idx *index,
-                     const struct kvgroup *kv_grp);
+int cortx_kvs_list_set(struct kvs_idx *index,
+                       const struct kvgroup *kv_grp);
 
 /** Get list of key-value pairs
  *  @param kv_grp - pointer to kv_group which fetches values for given keys
  *  @return 0 if successful, else return error code.
  */
-int eos_kvs_list_get(struct kvs_idx *index,
-                     struct kvgroup *kv_grp);
+int cortx_kvs_list_get(struct kvs_idx *index,
+                       struct kvgroup *kv_grp);
 
 #endif

--- a/nsal/src/include/kvstore.h
+++ b/nsal/src/include/kvstore.h
@@ -19,7 +19,7 @@
  
  /* This file contains KVStore framework infrastructure.
  There are currently 2 users of this infrastructure,
-	1. eos_kvs
+	1. cortx_kvs
 	2. redis
 
  This gives capability of basic key-value storing.

--- a/nsal/src/kvstore/kvstore_base.c
+++ b/nsal/src/kvstore/kvstore_base.c
@@ -39,7 +39,7 @@ struct kvstore_module {
 };
 
 static struct kvstore_module kvstore_modules[] = {
-    { "cortx", &eos_kvs_ops },
+    { "cortx", &cortx_kvs_ops },
 #ifdef	WITH_REDIS
     { "redis", &redis_kvs_ops },
 #endif
@@ -101,7 +101,7 @@ int kvs_fini(struct kvstore *kvstore)
 
 int kvs_fid_from_str(const char *fid_str, kvs_idx_fid_t *out_fid)
 {
-	return eos_kvs_fid_from_str(fid_str, out_fid);
+	return cortx_kvs_fid_from_str(fid_str, out_fid);
 }
 
 int kvs_alloc(struct kvstore *kvstore, void **ptr, size_t size)

--- a/nsal/src/kvstore/plugins/eos/eos_kvstore.c
+++ b/nsal/src/kvstore/plugins/eos/eos_kvstore.c
@@ -25,18 +25,18 @@
 #include "internal/eos/eos_kvstore.h"
 #include <eos/helpers.h>
 
-int eos_kvs_init(struct collection_item *cfg_items)
+int cortx_kvs_init(struct collection_item *cfg_items)
 {
 	return m0init(cfg_items);
 }
 
-int eos_kvs_fini(void)
+int cortx_kvs_fini(void)
 {
 	m0fini();
 	return 0;
 }
 
-int eos_kvs_alloc(void **ptr, size_t size)
+int cortx_kvs_alloc(void **ptr, size_t size)
 {
 	*ptr = m0kvs_alloc(size);
 	if (*ptr == NULL)
@@ -45,13 +45,13 @@ int eos_kvs_alloc(void **ptr, size_t size)
 	return 0;
 }
 
-void eos_kvs_free(void *ptr)
+void cortx_kvs_free(void *ptr)
 {
 	return m0kvs_free(ptr);
 }
 
 
-int eos_kvs_index_create(const kvs_idx_fid_t *fid, struct kvs_idx *index)
+int cortx_kvs_index_create(const kvs_idx_fid_t *fid, struct kvs_idx *index)
 {
         int rc;
 	struct m0_uint128 mfid = M0_UINT128(0, 0);
@@ -61,8 +61,8 @@ int eos_kvs_index_create(const kvs_idx_fid_t *fid, struct kvs_idx *index)
 	index->index_priv = NULL;
 
 	if (fid == NULL) {
-		const char *vfid_str = eos_kvs_get_gfid();
-	        rc = eos_kvs_fid_from_str(vfid_str, &gfid);
+		const char *vfid_str = cortx_kvs_get_gfid();
+	        rc = cortx_kvs_fid_from_str(vfid_str, &gfid);
 
 		index->index_fid = gfid;
 
@@ -91,7 +91,7 @@ out:
         return rc;
 }
 
-int eos_kvs_index_delete(const kvs_idx_fid_t *fid)
+int cortx_kvs_index_delete(const kvs_idx_fid_t *fid)
 {
         int rc;
 	struct m0_uint128 mfid = M0_UINT128(0, 0);
@@ -108,7 +108,7 @@ int eos_kvs_index_delete(const kvs_idx_fid_t *fid)
         return rc;
 }
 
-int eos_kvs_index_open(const kvs_idx_fid_t *fid, struct kvs_idx *index)
+int cortx_kvs_index_open(const kvs_idx_fid_t *fid, struct kvs_idx *index)
 {
 	int rc;
 	struct m0_uint128 mfid = M0_UINT128(0, 0);
@@ -118,9 +118,9 @@ int eos_kvs_index_open(const kvs_idx_fid_t *fid, struct kvs_idx *index)
 	index->index_priv = NULL;
 
 	if (fid == NULL) {
-		const char *vfid_str = eos_kvs_get_gfid();
+		const char *vfid_str = cortx_kvs_get_gfid();
 
-	        rc = eos_kvs_fid_from_str(vfid_str, &gfid);
+	        rc = cortx_kvs_fid_from_str(vfid_str, &gfid);
 
 		index->index_fid = gfid;
 
@@ -146,7 +146,7 @@ out:
 	return rc;
 }
 
-int eos_kvs_index_close(struct kvs_idx *index)
+int cortx_kvs_index_close(struct kvs_idx *index)
 {
 	struct m0_clovis_idx *idx = (struct m0_clovis_idx *)index->index_priv;
 
@@ -159,59 +159,59 @@ int eos_kvs_index_close(struct kvs_idx *index)
 	return 0;
 }
 
-int eos_kvs_begin_transaction(struct kvs_idx *index)
+int cortx_kvs_begin_transaction(struct kvs_idx *index)
 {
 	return 0;
 }
 
-int eos_kvs_end_transaction(struct kvs_idx *index)
+int cortx_kvs_end_transaction(struct kvs_idx *index)
 {
 	return 0;
 }
 
-int eos_kvs_discard_transaction(struct kvs_idx *index)
+int cortx_kvs_discard_transaction(struct kvs_idx *index)
 {
 	return 0;
 }
 
-int eos_kvs_get_bin(struct kvs_idx *index, void *k, const size_t klen,
-		 void **v, size_t *vlen)
+int cortx_kvs_get_bin(struct kvs_idx *index, void *k, const size_t klen,
+		      void **v, size_t *vlen)
 {
 	return m0kvs_get(index->index_priv, k, klen, v, vlen);
 }
 
-int eos_kvs4_get_bin(void *k, const size_t klen, void **v, size_t *vlen)
+int cortx_kvs4_get_bin(void *k, const size_t klen, void **v, size_t *vlen)
 {
 	return m0kvs4_get(k, klen, v, vlen);
 }
 
-int eos_kvs_set_bin(struct kvs_idx *index, void *k, const size_t klen,
-		 void *v, const size_t vlen)
+int cortx_kvs_set_bin(struct kvs_idx *index, void *k, const size_t klen,
+		      void *v, const size_t vlen)
 {
 	return m0kvs_set(index->index_priv, k, klen, v, vlen);
 }
 
-int eos_kvs4_set_bin(void *k, const size_t klen, void *v, const size_t vlen)
+int cortx_kvs4_set_bin(void *k, const size_t klen, void *v, const size_t vlen)
 {
 	return m0kvs4_set(k, klen, v, vlen);
 }
 
-int eos_kvs_del_bin(struct kvs_idx *index, const void *key, size_t klen)
+int cortx_kvs_del_bin(struct kvs_idx *index, const void *key, size_t klen)
 {
 	return m0kvs_del(index->index_priv, (void *) key, klen);
 }
 
-int eos_kvs_gen_fid(kvs_idx_fid_t *index_fid)
+int cortx_kvs_gen_fid(kvs_idx_fid_t *index_fid)
 {
 	return m0kvs_idx_gen_fid((struct m0_uint128 *) index_fid);
 }
 
-const char *eos_kvs_get_gfid(void)
+const char *cortx_kvs_get_gfid(void)
 {
 	return m0_get_gfid();
 }
 
-int eos_kvs_fid_from_str(const char *fid_str, kvs_idx_fid_t *out_fid)
+int cortx_kvs_fid_from_str(const char *fid_str, kvs_idx_fid_t *out_fid)
 {
 	return m0_fid_sscanf(fid_str, (struct m0_fid *) out_fid);
 }
@@ -227,7 +227,7 @@ bool get_list_cb_size(char *k, void *arg)
 	return true;
 }
 
-int eos_kvs_get_list_size(void *ctx, char *pattern, size_t plen)
+int cortx_kvs_get_list_size(void *ctx, char *pattern, size_t plen)
 {
 	char initk[KLEN];
 	int size = 0;
@@ -252,25 +252,25 @@ _Static_assert(sizeof(struct m0kvs_key_iter) <=
 	       "m0kvs_key_iter does not fit into 'priv'");
 
 static inline
-struct m0kvs_key_iter *eos_key_iter_priv(struct kvs_itr *iter)
+struct m0kvs_key_iter *cortx_key_iter_priv(struct kvs_itr *iter)
 {
 	return (void *) &iter->priv[0];
 }
 
-void eos_kvs_iter_get_kv(struct kvs_itr *iter, void **key, size_t *klen,
-                          void **val, size_t *vlen)
+void cortx_kvs_iter_get_kv(struct kvs_itr *iter, void **key, size_t *klen,
+                           void **val, size_t *vlen)
 {
-	struct m0kvs_key_iter *priv = eos_key_iter_priv(iter);
+	struct m0kvs_key_iter *priv = cortx_key_iter_priv(iter);
 	return m0kvs_key_iter_get_kv(priv, key, klen, val, vlen);
 }
 
-int eos_kvs_prefix_iter_has_prefix(struct kvs_itr *iter)
+int cortx_kvs_prefix_iter_has_prefix(struct kvs_itr *iter)
 {
 	void *key, *value;
 	size_t key_len, val_len;
 	int rc = 0;
 
-	eos_kvs_iter_get_kv(iter, &key, &key_len, &value, &val_len);
+	cortx_kvs_iter_get_kv(iter, &key, &key_len, &value, &val_len);
 	assert(key_len >= iter->prefix.len);
 	rc = memcmp(iter->prefix.buf, key, iter->prefix.len);
 	if (rc != 0) {
@@ -286,74 +286,74 @@ int eos_kvs_prefix_iter_has_prefix(struct kvs_itr *iter)
  * @return True if found, otherwise False. @see kvs_itr::inner_rc for return
  * code.
  */
-int eos_kvs_prefix_iter_find(struct kvs_itr *iter)
+int cortx_kvs_prefix_iter_find(struct kvs_itr *iter)
 {
 	int rc = 0;
 	struct m0kvs_key_iter *priv = NULL;
 
-	priv = eos_key_iter_priv(iter);
+	priv = cortx_key_iter_priv(iter);
 	priv->index = iter->idx.index_priv;
 	rc = m0kvs_key_iter_find(iter->prefix.buf, iter->prefix.len, priv);
 	iter->inner_rc = rc;
 	if (rc) {
 		goto out;
 	}
-	rc = eos_kvs_prefix_iter_has_prefix(iter);
+	rc = cortx_kvs_prefix_iter_has_prefix(iter);
 out:
 	return rc;
 }
 
 /* Find the next record and set iter to it. */
-int eos_kvs_prefix_iter_next(struct kvs_itr *iter)
+int cortx_kvs_prefix_iter_next(struct kvs_itr *iter)
 {
 	int rc = 0;
-	struct m0kvs_key_iter *priv = eos_key_iter_priv(iter);
+	struct m0kvs_key_iter *priv = cortx_key_iter_priv(iter);
 	rc = m0kvs_key_iter_next(priv);
 	iter->inner_rc = rc;
 	if (rc) {
 		goto out;
 	}
-	rc = eos_kvs_prefix_iter_has_prefix(iter);
+	rc = cortx_kvs_prefix_iter_has_prefix(iter);
 out:
 	return rc;
 }
 
 /** Cleanup key iterator object */
-void eos_kvs_prefix_iter_fini(struct kvs_itr *iter)
+void cortx_kvs_prefix_iter_fini(struct kvs_itr *iter)
 {
-	struct m0kvs_key_iter *priv = eos_key_iter_priv(iter);
+	struct m0kvs_key_iter *priv = cortx_key_iter_priv(iter);
 	m0kvs_key_iter_fini(priv);
 }
 
-struct kvstore_ops eos_kvs_ops = {
-	.init = eos_kvs_init,
-	.fini = eos_kvs_fini,
-	.alloc = eos_kvs_alloc,
-	.free = eos_kvs_free,
+struct kvstore_ops cortx_kvs_ops = {
+	.init = cortx_kvs_init,
+	.fini = cortx_kvs_fini,
+	.alloc = cortx_kvs_alloc,
+	.free = cortx_kvs_free,
 
-	.begin_transaction = eos_kvs_begin_transaction,
-	.end_transaction = eos_kvs_end_transaction,
-	.discard_transaction = eos_kvs_discard_transaction,
+	.begin_transaction = cortx_kvs_begin_transaction,
+	.end_transaction = cortx_kvs_end_transaction,
+	.discard_transaction = cortx_kvs_discard_transaction,
 
-	.index_create = eos_kvs_index_create,
-	.index_delete = eos_kvs_index_delete,
-	.index_open = eos_kvs_index_open,
-	.index_close = eos_kvs_index_close,
-	.index_gen_fid = eos_kvs_gen_fid,
+	.index_create = cortx_kvs_index_create,
+	.index_delete = cortx_kvs_index_delete,
+	.index_open = cortx_kvs_index_open,
+	.index_close = cortx_kvs_index_close,
+	.index_gen_fid = cortx_kvs_gen_fid,
 
-	.get_bin = eos_kvs_get_bin,
-	.get4_bin = eos_kvs4_get_bin,
-	.set_bin = eos_kvs_set_bin,
-	.del_bin = eos_kvs_del_bin,
+	.get_bin = cortx_kvs_get_bin,
+	.get4_bin = cortx_kvs4_get_bin,
+	.set_bin = cortx_kvs_set_bin,
+	.del_bin = cortx_kvs_del_bin,
 
-	.kv_find = eos_kvs_prefix_iter_find,
-	.kv_next = eos_kvs_prefix_iter_next,
-	.kv_fini = eos_kvs_prefix_iter_fini,
-	.kv_get = eos_kvs_iter_get_kv
+	.kv_find = cortx_kvs_prefix_iter_find,
+	.kv_next = cortx_kvs_prefix_iter_next,
+	.kv_fini = cortx_kvs_prefix_iter_fini,
+	.kv_get = cortx_kvs_iter_get_kv
 };
 
-int eos_kvs_list_set(struct kvs_idx *index,
-                     const struct kvgroup *kv_grp)
+int cortx_kvs_list_set(struct kvs_idx *index,
+                       const struct kvgroup *kv_grp)
 {
 	struct m0kvs_list key, val;
 	int rc = 0, i;
@@ -383,8 +383,8 @@ out:
 	return rc;
 }
 
-int eos_kvs_list_get(struct kvs_idx *index,
-                     struct kvgroup *kv_grp)
+int cortx_kvs_list_get(struct kvs_idx *index,
+                       struct kvgroup *kv_grp)
 {
 	struct m0kvs_list key, val;
 	int rc = 0, i;

--- a/nsal/src/test/ut/ut_nsal_kvtree_ops.c
+++ b/nsal/src/test/ut/ut_nsal_kvtree_ops.c
@@ -100,7 +100,7 @@ static int ut_kvtree_setup()
 	int rc = 0;
 	/* Creating namespace */
 	str256_t ns_name;
-	char *name = "eosfs";
+	char *name = "efs";
 	size_t ns_size = 0;
 
 	rc = nsal_module_init(cfg_items);

--- a/nsal/src/test/ut/ut_nsal_ns_ops.c
+++ b/nsal/src/test/ut/ut_nsal_ns_ops.c
@@ -88,7 +88,7 @@ static void test_ns_create_delete(void)
 {
 	int rc = 0;
 	str256_t ns_name;
-	char *name = "eosfs";
+	char *name = "efs";
 	struct namespace *ns;
 	size_t ns_size = 0;
 

--- a/utils/src/include/str.h
+++ b/utils/src/include/str.h
@@ -17,8 +17,8 @@
  * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
-#ifndef _EOS_STR_H_
-#define _EOS_STR_H_
+#ifndef _CORTX_STR_H_
+#define _CORTX_STR_H_
 
 #include <stdint.h>
 #include <debug.h>
@@ -72,4 +72,4 @@ typedef struct str256 str256_t;
 /* str256_isalphanum: Validate if ns_name is alpha numeric */
 int str256_isalphanum(const str256_t *name);
 
-#endif /* _EOS_STR_H_ */
+#endif /* _CORTX_STR_H_ */

--- a/utils/src/include/utils.h
+++ b/utils/src/include/utils.h
@@ -17,8 +17,8 @@
  * please email opensource@seagate.com or cortx-questions@seagate.com. 
  */
 
-#ifndef _EOS_UTILS_H_
-#define _EOS_UTILS_H_
+#ifndef _CORTX_UTILS_H_
+#define _CORTX_UTILS_H_
 
 #include <stdint.h>
 #include <linux/limits.h>
@@ -54,5 +54,5 @@ int utils_init(struct collection_item *cfg_items);
  */
 int utils_fini(void);
 
-#endif /* _EOS_UTILS_H_ */
+#endif /* _CORTX_UTILS_H_ */
 

--- a/utils/src/ut/ut.c
+++ b/utils/src/ut/ut.c
@@ -20,7 +20,7 @@
 #include <debug.h>
 #include "ut.h"
 
-/* This macro enables self tests in eos-utils ut library.
+/* This macro enables self tests in cortx-utils ut library.
  * The self test ensures that the API is stable enough to be
  * consumed by the users.
  * Disable the self test to speed up execution of each individual ut binary.


### PR DESCRIPTION
**Problem Statement**
EOS-11992 Rename eos to cortx in source code

**Problem Description**
Replace 'eos' with 'cortx' where eos is present in format eos_xxx (eos_xxx to cortx_xxx)  in CORTX-POSIX repository.
Note : This will not cover standalone occurence of 'eos' or 'EOS'

**Solution Overview**
Replaced all occurrences of the eos/EOS with cortx/CORTX in .c and .h files

**Unit Test Cases**

bash-4.2$ sudo ./scripts/test.sh

NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

EFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 12
Tests passed = 12
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

**Cthon**
-bash-4.2$ sudo ./kvsfs-ganesha/test/run_cthon.sh -m /mnt/dir1 -p fs1
sh ./runtests  -a -t /mnt/dir1/ssc-vm-c-0342.test

Starting BASIC tests: test directory /mnt/dir1/ssc-vm-c-0342.test (arg: -t)

./test1: File and directory creation test
        created 4 files 2 directories 2 levels deep in 2.30 seconds
        ./test1 ok.

./test2: File and directory removal test
        removed 4 files 2 directories 2 levels deep in 3.24 seconds
        ./test2 ok.

./test3: lookups across mount point
        500 getcwd and stat calls in 0.0  seconds
        ./test3 ok.

./test4: setattr, getattr, and lookup
        1000 chmods and stats on 10 files in 158.33 seconds
        ./test4 ok.
./test4a: getattr and lookup
        1000 stats on 10 files in 0.2  seconds
        ./test4a ok.

TESTARG=-t
./test6: readdir
        7500 entries read, 120 files in 704.90 seconds
        ./test6 ok.

./test7: link and rename
        200 renames and links on 10 files in 144.19 seconds
        ./test7 ok.

./test8: symlink and readlink
        400 symlinks and readlinks on 10 files in 164.7  seconds
        ./test8 ok.

./test9: statfs
        1500 statfs calls in 29.69 seconds
        ./test9 ok.

Congratulations, you passed the basic tests!