### PR TITLE
EOS-11840: Bug fix for failing of ganesha while creating more than 6 endpoints

### DIFF
--- a/kvsfs-ganesha/src/FSAL/FSAL_KVSFS/config/config_impl.c
+++ b/kvsfs-ganesha/src/FSAL/FSAL_KVSFS/config/config_impl.c
@@ -66,10 +66,12 @@ static void reserve(struct serialized_buffer *buffer, int capacity)
 {
 	buffer->data = realloc(buffer->data, capacity);
 	assert(buffer->data != NULL);
+	/* Update buffer capacity with new capacity */
+	buffer->capacity = capacity;
 }
 
 /* append data into buffer.
- * 
+ *
  * @param[out]; buffer - data container.
  * @param[in]: data - data source.
  * @paramo[in]: len - number of bytes to copy from data to buffer.


### PR DESCRIPTION
## Problem Statement

_[EOS-11840](https://jts.seagate.com/browse/EOS-11840):_
NFS Ganesha service failed while creating more than 6 endpoints using shell script.

## Problem Description
Creation of 100 filesystems was success, but for same when endpoints were created, nfs-ganesha failed after 6 endpoint creation. When root-caused, found in the backtrace of nfs-ganesha that: 
failure in `append_data()` function. Somehow the buffer pointer wasn't updated properly, which is used to dump the data in the ganesha config file.


## Solution Overview

_When the number of endpoints is 7( or more), the buffer pointer's capacity is exceeded (default is 2048). Hence buffer->data pointer is reallocated with: `realloc(buffer->data, memory = capacity *2)`. However, buffer->capacity wasn't updated to the new value._

## Unit Test Cases
_No UT for this code change_

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [x] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _Manual testing of creation of 100 endpoints conducted_         
