### PR TITLE
DSAL:Added test case to validate DSAL write/read IO implementation

### DIFF
--- a/dsal/src/test/dsal_test_lib.h
+++ b/dsal/src/test/dsal_test_lib.h
@@ -59,8 +59,12 @@ void dtlib_teardown(void);
 /* Fill buffer with some non-zero data. */
 static inline void dtlib_fill_data_block(uint8_t *data, size_t size)
 {
-	uint8_t value = 0;
+	uint8_t value;
 	size_t i;
+
+	/* Let's initialize the given buffer with random pattern */
+	srand(time(NULL));
+	value = rand() % UINT8_MAX;
 
 	for (i = 0; i < size; i++) {
 		data[i] = value;


### PR DESCRIPTION
# DSAL Change Summary

## Problem Statement

_[EOS-10801](https://jts.seagate.com/browse/EOS-10801):_
_Add UT to validate DSAL read and write operation._

## Problem Description

_As a part of design change proposal under [EOS-4776](https://jts.seagate.com/browse/EOS-4776) WRITE path implementation was done in [EOS-8181](https://jts.seagate.com/browse/EOS-8181), READ path implementation was was done in [EOS-8184](https://jts.seagate.com/browse/EOS-8184), so validation for the implementation with complex test cases was yet to be done_

## Solution Overview

_Have added the test cases which can be added to regress the implemented write/read code path_

## Unit Test Cases
_Already existing UTs for validating this code path in DSAL are passing_
### Following new test case has been added

- _Read a deleted file is passing_

- _Writing/Reading a large aligned buffer [8k, 16k,1M] is passing_

- _Overwrite Test - Write data, Read data, Verify data, Write again, Read again, Verify again is passing_

- _Validate` the reading a hole bug scenario is passing_

## Testing
<details>
  <summary>Click here to see the test execution output</summary>

```
# /tmp/eos-fs/build-dsal/test/dsal_test_basic
[==========] Running 11 test(s).
[ RUN      ] test_creat_del_basic
[       OK ] test_creat_del_basic
[ RUN      ] test_creat_existing
[       OK ] test_creat_existing
[ RUN      ] test_del_non_existing
[       OK ] test_del_non_existing
[ RUN      ] test_open_close_basic
[       OK ] test_open_close_basic
[ RUN      ] test_write_basic
[       OK ] test_write_basic
[ RUN      ] test_read_basic
[       OK ] test_read_basic
[ RUN      ] test_open_non_existing
[       OK ] test_open_non_existing
[ RUN      ] test_delete_open
[       OK ] test_delete_open
[ RUN      ] test_read_deleted_file
[       OK ] test_read_deleted_file
[ RUN      ] test_write_read_aligned
test_write_read_validate w_size = 4k, w_offset = 0k r_size = 4k, r_offset = 0k
test_write_read_validate w_size = 8k, w_offset = 0k r_size = 8k, r_offset = 0k
test_write_read_validate w_size = 16k, w_offset = 0k r_size = 16k, r_offset = 0k
test_write_read_validate w_size = 1024k, w_offset = 0k r_size = 1024k, r_offset = 0k
[       OK ] test_write_read_aligned
[ RUN      ] test_holes_in_file
test_write_read_validate w_size = 4k, w_offset = 0k r_size = 8k, r_offset = 0k
test_write_read_validate w_size = 4k, w_offset = 4k r_size = 8k, r_offset = 4k
rc = -ENOENT for w_size = 4k, w_offset = 4k r_size = 8k, r_offset = 4k
test_write_read_validate w_size = 4k, w_offset = 8k r_size = 8k, r_offset = 8k
test_write_read_validate w_size = 4k, w_offset = 12k r_size = 8k, r_offset = 12k
test_write_read_validate w_size = 4k, w_offset = 16k r_size = 8k, r_offset = 16k
test_write_read_validate w_size = 4k, w_offset = 20k r_size = 8k, r_offset = 20k
test_write_read_validate w_size = 4k, w_offset = 24k r_size = 8k, r_offset = 24k
test_write_read_validate w_size = 4k, w_offset = 28k r_size = 8k, r_offset = 28k
test_write_read_validate w_size = 4k, w_offset = 32k r_size = 8k, r_offset = 32k
test_write_read_validate w_size = 4k, w_offset = 36k r_size = 8k, r_offset = 36k
test_write_read_validate w_size = 4k, w_offset = 40k r_size = 8k, r_offset = 40k
test_write_read_validate w_size = 4k, w_offset = 44k r_size = 8k, r_offset = 44k
test_write_read_validate w_size = 4k, w_offset = 48k r_size = 8k, r_offset = 48k
test_write_read_validate w_size = 4k, w_offset = 52k r_size = 8k, r_offset = 52k
test_write_read_validate w_size = 4k, w_offset = 56k r_size = 8k, r_offset = 56k
test_write_read_validate w_size = 4k, w_offset = 60k r_size = 8k, r_offset = 60k
test_write_read_validate w_size = 8k, w_offset = 0k r_size = 16k, r_offset = 0k
rc = -ENOENT for w_size = 8k, w_offset = 0k r_size = 16k, r_offset = 0k
test_write_read_validate w_size = 8k, w_offset = 8k r_size = 16k, r_offset = 8k
test_write_read_validate w_size = 8k, w_offset = 16k r_size = 16k, r_offset = 16k
test_write_read_validate w_size = 8k, w_offset = 24k r_size = 16k, r_offset = 24k
test_write_read_validate w_size = 8k, w_offset = 32k r_size = 16k, r_offset = 32k
test_write_read_validate w_size = 8k, w_offset = 40k r_size = 16k, r_offset = 40k
test_write_read_validate w_size = 8k, w_offset = 48k r_size = 16k, r_offset = 48k
test_write_read_validate w_size = 8k, w_offset = 56k r_size = 16k, r_offset = 56k
test_write_read_validate w_size = 16k, w_offset = 0k r_size = 32k, r_offset = 0k
test_write_read_validate w_size = 16k, w_offset = 16k r_size = 32k, r_offset = 16k
test_write_read_validate w_size = 16k, w_offset = 32k r_size = 32k, r_offset = 32k
test_write_read_validate w_size = 16k, w_offset = 48k r_size = 32k, r_offset = 48k
test_write_read_validate w_size = 32k, w_offset = 0k r_size = 64k, r_offset = 0k
test_write_read_validate w_size = 32k, w_offset = 32k r_size = 64k, r_offset = 32k
test_write_read_validate w_size = 64k, w_offset = 0k r_size = 128k, r_offset = 0k
[       OK ] test_holes_in_file
[==========] 11 test(s) run.
[  PASSED  ] 11 test(s).
```
  
</details>

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [x] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _As mentioned in description existing and newly implemented UTs are passing_
- [x] **Documentation:** _This patch, merge request, Jira ticket [EOS-10801](https://jts.seagate.com/browse/EOS-10801) have up to date description_