### PR TITLE
PNFS config block parsing error.

### DIFF
--- a/kvsfs-ganesha/src/FSAL/FSAL_KVSFS/config/config_impl.c
+++ b/kvsfs-ganesha/src/FSAL/FSAL_KVSFS/config/config_impl.c
@@ -95,7 +95,13 @@ void json_to_dataserver_block(struct json_object *obj, struct ds_block *block)
 
 	json_object_object_get_ex(obj, "data_server", &json_obj);
 	if (json_obj == NULL) {
-		str = "None";
+		// @HOTFIX:
+		// This is mandatory field, So it should be valid.
+		// IF pnfs_enabled = false
+		// 	DS_Addr = <Any Valid IP>
+		// ELSE
+		// 	DS_Addr = <DS_IP_ADDR>
+		str = "127.0.0.1";
 	} else {
 		str = json_object_get_string(json_obj);
 	}
@@ -122,14 +128,9 @@ void json_to_pnfs_block(struct json_object *obj, struct pnfs_block *block)
 	}
 	str256_from_cstr(block->pnfs_enabled, str, strlen(str));
 
-	json_object_object_get_ex(obj, "data_server", &json_obj);
-	if (json_obj == NULL) {
-		str = "0";
-		str256_from_cstr(block->ds_count, str, strlen(str));
-	} else {
-		str = "1";
-		str256_from_cstr(block->ds_count, str, strlen(str));
-	}
+	// We are supporting only one Data-Server right now.
+	str = "1";
+	str256_from_cstr(block->ds_count, str, strlen(str));
 
 	json_to_dataserver_block(obj, &block->ds_block);
 	return;


### PR DESCRIPTION
# EFS Change Summary
## Problem Statement
[EOS-10931](https://jts.seagate.com/browse/EOS-10931) Fix config parsing for PNFS block when when pnfs options are not provided.

## Problem Description
Config parsing error for pNFS block from export entry.
It is due to invalid values of default entries for pNFS block when not provided.

## Solution Overview
This patch provides the support for nfs_setup.sh to configure pNFS roles..
Please find the HLD at section **getdeviceinfo**: 
[pNFS Roles design and HLD](https://seagatetechnology.sharepoint.com/:w:/r/sites/CORTX/_layouts/15/Doc.aspx?sourcedoc=%7B03DDFA76-4EC3-4097-AB1A-A4D2A69BBDEA%7D&file=pnfs_mds_design.docx&action=default&mobileredirect=true)

## Unit Test Cases

# MR checklist
- [x] Compilation: This patch does not break compilation ( )

- [x] Documentation: This patch and the merge request have up-to-date descriptions.

- [x] Dependencies:  This is independent patch  .

- [x] Merge conflicts: This patch has been squashed and re-based, it can be merged using fast-forward merge.

- [x] Code review: All discussions have been addressed.