### PR TITLE
EOS-8892: Introduce entry/exist points for KVSFS WRITE.

### DIFF
--- a/kvsfs-ganesha/src/FSAL/FSAL_KVSFS/CMakeLists.txt
+++ b/kvsfs-ganesha/src/FSAL/FSAL_KVSFS/CMakeLists.txt
@@ -65,6 +65,15 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${CAPIINC}")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unused-variable")
 
+# Turns on ADDB-based TDSB wrappers.
+# When this flag is disabled, KVSFS will be used the no-oop
+# wrappers.
+# When this flag is enabled, the utils module has to be
+# be compiled with this flag enabled otherwise some of
+# the function calls will be undefined.
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DENABLE_TSDB_ADDB")
+
+
 # TODO: Wrap this with a check against build type
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g3 -fPIC")
 # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all")

--- a/utils/src/eos/m0common.c
+++ b/utils/src/eos/m0common.c
@@ -25,6 +25,7 @@
 #include "m0common.h"
 #include <common/log.h>
 #include <debug.h> /* dassert */
+#include "perf/tsdb.h" /* is_engine_on */
 
 /* To be passed as argument */
 struct m0_clovis_realm     clovis_uber_realm;
@@ -233,6 +234,7 @@ int init_clovis(void)
 	clovis_conf.cc_idx_service_id	= M0_CLOVIS_IDX_DIX;
 	dix_conf.kc_create_meta		= false;
 	clovis_conf.cc_idx_service_conf	= &dix_conf;
+	clovis_conf.cc_is_addb_init	= tsdb_is_engine_on();
 
 	/* Create Clovis instance */
 	rc = m0_clovis_init(&clovis_instance, &clovis_conf, true);

--- a/utils/src/eos/m0kvs.c
+++ b/utils/src/eos/m0kvs.c
@@ -22,6 +22,7 @@
 #include "addb2/global.h" /* global_leave */
 #include "common/log.h"
 #include <debug.h>
+#include "perf/tsdb.h"
 
 int m0kvs_reinit(void)
 {
@@ -40,6 +41,9 @@ void m0kvs_do_init(void)
 	}
 
 	log_config();
+
+	/** TODO: Create a config file parameter. */
+	tsdb_init(true, true);
 
 	rc = init_clovis();
 	assert(rc == 0);


### PR DESCRIPTION
Problem: We have not started using ADDB yet for
instrumenting our code. We need to initiate this
process. KVSFS Write is good entry point
for that.
Solution: Enable ADDB-based TSDB wrappers,
turn it on, and add opstack_begin/opstack_end
calls into KVSFS for the WRITE operation.

Testing: the patch can be tested manually using the following
instructions.

Start NFS Ganesha. In my experiments I run it under GDB:

```sh
rm -fR /tmp/1.log && gdb --args ganesha.nfsd -L /tmp/1.log -F -N \
NIV_FULL_DEBUG -f /etc/ganesha/ganesha.conf
```

Then mount, perform IO, umount it, wait a bit and then kill it:

```sh
mount -t nfs4 -o vers=4.0  ssc-vm-0025:/ /mnt/
for i in {0..16}; do dd if=/dev/zero of=/mnt/kvsns/f1 bs=4K count=1; \
done
umount /mnt
sleep 30
killall  ganesha.nfsd
```

Then decode the binary ADDB stob into a plain-text file:

```sh
m0addb2dump -- $PWD/$(ls -t clovis_addb*  | head -n 1 | sed \
's/://')/o/100000000000000\:2  > /tmp/addb
```

Now you can try to "grep" the action ID that related to
the write operation:

```sh
 grep '24000 ?' /tmp/addb

* 2020-08-20-02:25:51.793531151            24000 ?               b?, ?
* 4?, ?               1?, ?               0?, ?               1?, ?
* 1000?
* 2020-08-20-02:25:51.802153901            24000 ?               e?, ?
* 4?, ?               0?, ?               0?
* 2020-08-20-02:25:52.069242663            24000 ?               b?, ?
* 9?, ?               1?, ?               0?, ?               1?, ?
* 1000?
* 2020-08-20-02:25:52.078028958            24000 ?               e?, ?
* 9?, ?               0?, ?               0?
* 2020-08-20-02:25:52.343211289            24000 ?               b?, ?
* e?, ?               1?, ?               0?, ?               1?, ?
* 1000?
* 2020-08-20-02:25:52.352640962            24000 ?               e?, ?
* e?, ?               0?, ?               0?
```

Here we have the action id (24000), subtag for entry point (b),
subtag for exit point (e), various call_id's (4, 9, e). The next 4
arguments describe IO operation (entry point): stable/unstable,
offset, number of IO vectors (always 1) and IO size (1000 hex == 4K).

Signed-off-by: Ivan Alekhin <ivan.alekhin@seagate.com>