### PR TITLE
EOS-11149: The OpenAPI spec yaml file used to generate the REST API reference document.

### DIFF
--- a/efs/src/management/openapi.yaml
+++ b/efs/src/management/openapi.yaml
@@ -1,0 +1,343 @@
+openapi: 3.0.0
+info:
+  title: Control Server REST APIs
+  version: '1.0'
+  description: |-
+    REST APIs introduced here uses standard HTTPS requests and responses.
+
+    Many of the API operations require JSON in the request body or return JSON
+    in the response body. The specific contents of the JSON are described in
+    the API documentation for the individual operation.
+
+    REST APIs described here uses only three HTTP methods.
+
+    - PUT - For creating, updating a record.
+    - GET - For reading records.
+    - DELETE - For deleting records.
+
+    **Note**: For viewing the curl command usage, click on *'Try it out'* and
+    then *'Execute'*.
+
+servers:
+  - url: 'http://localhost:8081'
+paths:
+
+  /fs:
+
+    get:
+      summary: Filesystem List
+      tags:
+        - fs
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  fs-name:
+                    $ref : '#/components/schemas/fsname'
+                  fs-options:
+                    type: string
+                  endpoint-options:
+                    $ref : '#/components/schemas/export_options'
+              examples:
+                example-1:
+                  value:
+                    - fs-name: testfs
+                      fs-options: null
+                      endpoint-options:
+                        proto: nfs
+                        secType: sys
+                        Filesystem_id: '192.1'
+                        client: '1'
+                        clients: '*'
+                        Squash: no_root_squash
+                        access_type: RW
+                        protocols: '4'
+                        pnfs_enabled: 'false'
+                        data_server: 10.230.244.42
+                    - fs-name: testfs2
+                      fs-options: null
+                      endpoint-options: null
+                    - fs-name: testfs3
+                      fs-options: null
+                      endpoint-options: null
+                    - fs-name: shreya
+                      fs-options: null
+                      endpoint-options:
+                        proto: nfs
+                        secType: sys
+                        Filesystem_id: '192.2'
+                        client: '1'
+                        clients: '*'
+                        Squash: no_root_squash
+                        access_type: RW
+                        protocols: '4'
+      operationId: get-fs
+      description: Returns a list of all filesystems created at the backend.
+
+    put:
+      summary: Filesytem Create
+      operationId: put-fs
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref : '#/components/schemas/rcError'
+              examples:
+                example-1:
+                  value:
+                    rc: 22
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref : '#/components/schemas/rcError'
+              examples:
+                example-1:
+                  value:
+                    rc: 17
+      description: |-
+        Creates a new filesystem with the given fs-name. The name of the
+        filesystem has to be unique.
+        Created filesystem cannot be mounted until it has been exported.
+
+        Note: Once a filesystem is created, it cannot be updated.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              maxProperties: 1
+              minProperties: 1
+              properties:
+                name:
+                  $ref: '#/components/schemas/fsname'
+              required:
+                - name
+            examples:
+              example1:
+                value:
+                  name: testFS
+        description: Name of the filesystem
+      parameters: []
+      tags:
+        - fs
+    parameters: []
+
+  '/fs/{fsname}':
+    parameters:
+      - schema:
+          $ref : '#/components/schemas/fsname'
+        name: fsname
+        in: path
+        required: true
+        description: Name of the filesystem to be deleted
+
+    delete:
+      summary: Filesystem delete
+      operationId: delete-fs-fsname
+      responses:
+        '200':
+          description: OK
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref : '#/components/schemas/rcError'
+              examples:
+                example-1:
+                  value:
+                    rc: 22
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref : '#/components/schemas/rcError'
+              examples:
+                example-1:
+                  value:
+                    rc: 2
+      description: |-
+        Deletes the specified file system.
+
+        Note: A filesystem cannot be deleted, if it's export resource still
+        references it.
+      tags:
+        - fs
+
+  /endpoint:
+
+    put:
+      summary: Export create
+      operationId: put-endpoint
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref : '#/components/schemas/rcError'
+              examples:
+                example-1:
+                  value:
+                    rc: 22
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref : '#/components/schemas/rcError'
+              examples:
+                example-1:
+                  value:
+                    rc: 2
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref : '#/components/schemas/rcError'
+              examples:
+                example-1:
+                  value:
+                    rc: 17
+      description: |-
+        Creates a new export for the specified filesystem.
+
+        Note: For creating an export, the filesystem should be created before.
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  $ref : '#/components/schemas/fsname'
+                options:
+                  $ref : '#/components/schemas/export_options'
+              required:
+                - name
+                - options
+            examples:
+              example-1:
+                value:
+                  name: testfs
+                  options:
+                    proto: nfs
+                    secType: sys
+                    Filesystem_id: '192.1'
+                    client: '1'
+                    clients: '*'
+                    Squash: no_root_squash
+                    access_type: RW
+                    protocols: '4'
+        description: |-
+          The request body includes filesystem name along with export options.
+
+          Note: Filesystem name acts as the export name.
+      tags:
+        - endpoint
+
+  '/endpoint/{endpoint_name}':
+    parameters:
+      - schema:
+          $ref : '#/components/schemas/fsname'
+        name: endpoint_name
+        in: path
+        required: true
+        description: Name of the export to be deleted
+
+    delete:
+      summary: Export Delete
+      operationId: delete-endpoint-endpoint_name
+      responses:
+        '200':
+          description: OK
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref : '#/components/schemas/rcError'
+              examples:
+                example-1:
+                  value:
+                    rc: 22
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref : '#/components/schemas/rcError'
+              examples:
+                example-1:
+                  value:
+                    rc: 2
+      description: Deletes the specified export.
+      tags:
+        - endpoint
+
+components:
+
+  schemas:
+    rcError:
+      type: object
+      properties:
+        rc:
+          type: integer
+
+    fsname:
+      type: string
+      pattern: '^[A-Za-z0-9/]'
+      maxLength: 255
+      example: testfs
+      minLength: 1
+
+    export_options:
+      type: object
+      required:
+        - proto
+        - secType
+        - Filesystem_id
+        - client
+        - clients
+        - Squash
+        - access_type
+        - protocols
+      properties:
+        proto:
+          type: string
+        secType:
+          type: string
+        Filesystem_id:
+          type: string
+        client:
+          type: string
+        clients:
+          type: string
+        Squash:
+          type: string
+        access_type:
+          type: string
+        protocols:
+          type: string
+
+tags:
+  - name: fs
+    description: "Filesystem operations"
+
+  - name: endpoint
+    description: "Endpoint operations"


### PR DESCRIPTION
## Problem Statement

_[EOS-11149](https://jts.seagate.com/browse/EOS-11149):_
The OpenAPI spec yaml file is used to generate the REST API reference document.

## Problem Description
This openapi spec yaml file acts as a input to swagger tool. The API reference doc generated also acts like a REST Client which can send REST requests.
This file can also be an input to generate automated test-case suits for validating all REST APIs.

The paths specified in the yaml file are defined in control server.

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _Manual testing of all the curl commands_         
