### PR TITLE
Eos 12305

### DIFF
--- a/utils/c-utils/src/management/request-handler.c
+++ b/utils/c-utils/src/management/request-handler.c
@@ -83,16 +83,20 @@ int request_validate_headers(struct request *request)
 	http = request->http;
 	content_length = http->header_find(http->evhtp_req->headers_in,
 					   "Content-Length");
-	if (content_length == NULL) {
-		/**
-		 * Invalid fs request.
-		 * Send error response.
-		 */
-		rc = EINVAL;
-		goto error;
+	/*
+	EOS-12305 : Initially we had a NULL check for content_length and
+	returned Error Code 22 in case it was NULL. Content Length is the 
+	length of the body (in bytes). For a REST Request the body usually
+	contains the parameters of the request. A Request may or may not
+	need parameters, so checking for NULL and failing is not recommended.
+	*/
+	if(content_length == NULL) {
+		request->in_content_len = 0;
+	}
+	else{
+		request->in_content_len = atoi(content_length);        
 	}
 
-	request->in_content_len = atoi(content_length);
 	request->in_remaining_len = request->in_content_len;
 
 	/**
@@ -100,7 +104,7 @@ int request_validate_headers(struct request *request)
 	 * Add more common fs validations
 	 * ...
 	 */
-error:
+
 	return rc;
 }
 


### PR DESCRIPTION
Made changes to code so that we dont have to pass Dummy Parameters for GET and DELETE requests.

Curl Command Results :

1. GET Filesystem 

> bash-4.2$ curl  -v  -X GET "http://localhost:8081/fs"
> * About to connect() to localhost port 8081 (#0)
> *   Trying 127.0.0.1...
> * Connected to localhost (127.0.0.1) port 8081 (#0)
> > GET /fs HTTP/1.1
> > User-Agent: curl/7.29.0
> > Host: localhost:8081
> > Accept: */*
> > 
> < HTTP/1.1 200 OK
> < Content-Type: application/json
> < Accept: application/json
> < Content-Length: 352
> < 
> * Connection #0 to host localhost left intact
> [ { "fs-name": "fs1", "fs-options": null, "endpoint-options": { "proto": "nfs", "secType": "sys", "Filesystem_id": "192.1", "client": "1", "clients": "*", "Squash": "no_root_squash", "access_type": "RW", "protocols": "4", "pnfs_enabled": "false", "data_server": "10.230.246.225" } }, { "fs-name": "fs2", "fs-options": null, "endpoint-options": null } ]

2. Delete FileSystem

> bash-4.2$ curl  -v  -X DELETE "http://localhost:8081/fs/fs2"
> * About to connect() to localhost port 8081 (#0)
> *   Trying 127.0.0.1...
> * Connected to localhost (127.0.0.1) port 8081 (#0)
> > DELETE /fs/fs2 HTTP/1.1
> > User-Agent: curl/7.29.0
> > Host: localhost:8081
> > Accept: */*
> > 
> < HTTP/1.1 200 OK
> < Content-Length: 
> < Content-Length: 0
> < Content-Type: text/plain
> < 
> * Connection #0 to host localhost left intact
> bash-4.2$ curl  -v  -X GET "http://localhost:8081/fs"
> * About to connect() to localhost port 8081 (#0)
> *   Trying 127.0.0.1...
> * Connected to localhost (127.0.0.1) port 8081 (#0)
> > GET /fs HTTP/1.1
> > User-Agent: curl/7.29.0
> > Host: localhost:8081
> > Accept: */*
> > 
> < HTTP/1.1 200 OK
> < Content-Type: application/json
> < Accept: application/json
> < Content-Length: 284
> < 
> * Connection #0 to host localhost left intact
> [ { "fs-name": "fs1", "fs-options": null, "endpoint-options": { "proto": "nfs", "secType": "sys", "Filesystem_id": "192.1", "client": "1", "clients": "*", "Squash": "no_root_squash", "access_type": "RW", "protocols": "4", "pnfs_enabled": "false", "data_server": "10.230.246.225" } } ]

3. Delete Endpoint

> bash-4.2$ curl -v -X DELETE "http://localhost:8081/endpoint/fs1"
> * About to connect() to localhost port 8081 (#0)
> *   Trying 127.0.0.1...
> * Connected to localhost (127.0.0.1) port 8081 (#0)
> > DELETE /endpoint/fs1 HTTP/1.1
> > User-Agent: curl/7.29.0
> > Host: localhost:8081
> > Accept: */*
> > 
> < HTTP/1.1 200 OK
> < Content-Length: 
> < Content-Length: 0
> < Content-Type: text/plain
> < 
> * Connection #0 to host localhost left intact
> bash-4.2$ curl  -v  -X GET "http://localhost:8081/fs"
> * About to connect() to localhost port 8081 (#0)
> *   Trying 127.0.0.1...
> * Connected to localhost (127.0.0.1) port 8081 (#0)
> > GET /fs HTTP/1.1
> > User-Agent: curl/7.29.0
> > Host: localhost:8081
> > Accept: */*
> > 
> < HTTP/1.1 200 OK
> < Content-Type: application/json
> < Accept: application/json
> < Content-Length: 70
> < 
> * Connection #0 to host localhost left intact
> [ { "fs-name": "fs1", "fs-options": null, "endpoint-options": null } ]


Test Suite Results :

> bash-4.2$ sudo ./scripts/test.sh 
>  
>  
> Configuration Completed
> Clean indexes prepared
> NSAL Unit tests
> NS Tests
> Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
> Total tests  = 5
> Tests passed = 5
> Tests failed = 0
> 
> Iterator test
> Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
> Total tests  = 2
> Tests passed = 2
> Tests failed = 0
> 
> KVTree test
> Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
> Total tests  = 17
> Tests passed = 17
> Tests failed = 0
> 
> EFS Unit tests
> Endpoint ops Tests
> Test results are logged to /var/log/cortx/test/ut/ut_efs.logs
> Total tests  = 4
> Tests passed = 4
> Tests failed = 0
> 
> FS Tests
> Test results are logged to /var/log/cortx/test/ut/ut_efs.log
> Total tests  = 3
> Tests passed = 3
> Tests failed = 0
> 
> Directory tests
> Test results are logged to /var/log/cortx/test/ut/ut_efs.log
> Total tests  = 12
> Tests passed = 12
> Tests failed = 0
> 
> File creation tests
> Test results are logged to /var/log/cortx/test/ut/ut_efs.log
> Total tests  = 3
> Tests passed = 3
> Tests failed = 0
> 
> Link Tests
> Test results are logged to /var/log/cortx/test/ut/ut_efs.log
> Total tests  = 6
> Tests passed = 6
> Tests failed = 0
> 
> Rename tests
> Test results are logged to /var/log/cortx/test/ut/ut_efs.log
> Total tests  = 3
> Tests passed = 3
> Tests failed = 0
> 
> Attribute Tests
> Test results are logged to /var/log/cortx/test/ut/ut_efs.log
> Total tests  = 5
> Tests passed = 5
> Tests failed = 0
> 
> Xattr file Tests
> Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
> Total tests  = 9
> Tests passed = 9
> Tests failed = 0
> 
> Xattr dir Tests
> Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
> Total tests  = 9
> Tests passed = 9
> Tests failed = 0
> 
> IO tests
> Test results are logged to /var/log/cortx/test/ut/ut_efs.log
> Total tests  = 6
> Tests passed = 6
> Tests failed = 0
> 


