### PR TITLE
EOS-12238: pNFS: MDS: Add preliminary support for multiple layout on…

### DIFF
--- a/cortx-fs-ganesha/src/FSAL/FSAL_CORTXFS/CMakeLists.txt
+++ b/cortx-fs-ganesha/src/FSAL/FSAL_CORTXFS/CMakeLists.txt
@@ -1,0 +1,187 @@
+cmake_minimum_required(VERSION 2.6.3)
+
+set(LIB_FS_GANESHA ${PROJECT_NAME_BASE}-fs-ganesha)
+
+PROJECT(${LIB_FS_GANESHA} C)
+
+include(CheckIncludeFiles)
+include(CheckLibraryExists)
+
+set(KVSFS_GANESHA_MAJOR_VERSION 1)
+set(KVSFS_GANESHA_MINOR_VERSION 0)
+set(KVSFS_GANESHA_PATCH_LEVEL 1)
+set(KVSFS_GANESHA_EXTRA_VERSION ${RELEASE_VER})
+
+set(KVSFS_GANESHA_BASE_VERSION ${BASE_VERSION})
+set(NFS_SETUP_DIR ${CMAKE_SOURCE_DIR}/conf)
+
+################################################################################
+# Required arguments
+
+set(DEFAULT_GANESHASRC "")
+set(DEFAULT_GANESHABUILD "")
+set(DEFAULT_CAPIINC "")
+set(DEFAULT_NSALINC "")
+set(DEFAULT_LIBNSAL "")
+set(DEFAULT_CORTXFSINC "")
+set(DEFAULT_LIBCORTXFS "")
+set(DEFAULT_CORTXUTILSINC "")
+set(DEFAULT_LIBCORTXUTILS "")
+
+set(CORTXUTILSINC ${DEFAULT_CORTXUTILSINC} CACHE PATH "Path to folder with fault.h")
+set(LIBCORTXUTILS ${DEFAULT_LIBCORTXUTILS} CACHE PATH "Path to folder with libcortx-utils.so")
+
+set(DEFAULT_CORTXUTILSINC "")
+set(DEFAULT_LIBCORTXUTILS "")
+
+set(CORTXUTILSINC ${DEFAULT_CORTXUTILSINC} CACHE PATH "Path to folder with fault.h")
+set(LIBCORTXUTILS ${DEFAULT_LIBCORTXUTILS} CACHE PATH "Path to folder with libcortx-utils.so")
+
+set(GANESHASRC ${DEFAULT_GANESHASRC} CACHE PATH "Path to NFS-Ganesha Source (nfs-ganesha/src)")
+set(GANESHABUILD ${DEFAULT_GANESHABUILD} CACHE PATH "Path to NFS-Ganesha Build (nfs-ganesha/build)")
+set(FSAL_DESTINATION "/usr/lib64/ganesha" CACHE PATH "Target directory for FSAL")
+set(CAPIINC ${DEFAULT_CAPIINC} CACHE PATH "Path to CAPI")
+set(NSALINC ${DEFAULT_NSALINC} CACHE PATH "Path to folder with nsal headers")
+set(LIBNSAL ${DEFAULT_LIBNSAL} CACHE PATH "Path to folder with libcortx-nsal.so")
+
+set(CORTXFSINC ${DEFAULT_CORTXFSINC} CACHE PATH "Path to folder with nsal headers")
+set(LIBCORTXFS ${DEFAULT_LIBCORTXFS} CACHE PATH "Path to folder with libcortx-nsal.so")
+
+set(PROJECT_NAME_BASE ${PROJECT_NAME_BASE})
+set(INSTALL_DIR_ROOT ${INSTALL_DIR_ROOT})
+
+# TODO: Add a condition here and check nfs-ganesha configuration
+set(SYSTEM_LIBRARIES
+	"/usr/lib64/libjemalloc.so")
+
+include_directories(${CMAKE_SOURCE_DIR})
+include_directories(${GANESHASRC}/libntirpc)
+include_directories(${GANESHASRC}/libntirpc/ntirpc)
+include_directories(${GANESHABUILD}/include)
+include_directories(${GANESHASRC}/include)
+include_directories(${GANESHASRC}/include/FSAL)
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${CAPIINC}")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unused-variable")
+
+# TODO: Wrap this with a check against build type
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g3 -fPIC")
+# set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all")
+
+set(CMAKE_REQUIRED_INCLUDES ${CORTXUTILSINC})
+
+CHECK_INCLUDE_FILES("fault.h" HAVE_CORTX_UTILS_H)
+
+message(STATUS "HAVE_CORTX_UTILS_H=${HAVE_CORTX_UTILS_H}")
+
+if(NOT HAVE_CORTX_UTILS_H)
+ if(STRICT_PACKAGE)
+    message(FATAL_ERROR "STRICT_PACKAGE: Cannot find CORTX-UTILS runtime. Disabling CORTXFS build")
+ else(STRICT_PACKAGE)
+    message(WARNING "Cannot find CORTX-UTILS runtime. Disabling CORTXFS build")
+    set(USE_CORTXFS OFF)
+  endif(STRICT_PACKAGE)
+endif(NOT HAVE_CORTX_UTILS_H)
+
+include_directories(${CORTXUTILSINC})
+link_directories(${LIBCORTXUTILS})
+
+include_directories(${NSALINC})
+link_directories(${LIBNSAL})
+
+include_directories(${CORTXFSINC})
+link_directories(${LIBCORTXFS})
+
+set(CMAKE_REQUIRED_INCLUDES ${CORTXUTILSINC})
+
+CHECK_INCLUDE_FILES("fault.h" HAVE_CORTX_UTILS_H)
+
+message(STATUS "HAVE_CORTX_UTILS_H=${HAVE_CORTX_UTILS_H}")
+
+if(NOT HAVE_CORTX_UTILS_H)
+ if(STRICT_PACKAGE)
+    message(FATAL_ERROR "STRICT_PACKAGE: Cannot find CORTX-UTILS runtime. Disabling KVSFS build")
+ else(STRICT_PACKAGE)
+    message(WARNING "Cannot find CORTX-UTILS runtime. Disabling KVSFS build")
+    set(USE_FSAL_CORTXFS OFF)
+  endif(STRICT_PACKAGE)
+endif(NOT HAVE_CORTX_UTILS_H)
+
+include_directories(${CORTXUTILSINC})
+link_directories(${LIBCORTXUTILS})
+
+add_subdirectory(config)
+set(LIBCONFIG libconfig)
+
+SET(fsalkvsfs_LIB_SRCS
+   fsal_internal.c
+   fsal_global_tables.c
+   main.c
+   export.c
+   handle.c
+   file.c
+   xattrs.c
+   mds.c
+   ds.c
+)
+
+add_library(libganesha OBJECT ${fsalkvsfs_LIB_SRCS})
+set(LIBGANESHA libganesha)
+
+add_library(${LIB_FS_GANESHA} SHARED
+	   $<TARGET_OBJECTS:${LIBGANESHA}>
+	   $<TARGET_OBJECTS:${LIBCONFIG}>
+	   )
+
+target_link_libraries(${LIB_FS_GANESHA}
+  ${PROJECT_NAME_BASE}-fs
+  ${SYSTEM_LIBRARIES}
+)
+
+set_target_properties(${LIB_FS_GANESHA} PROPERTIES VERSION 4.2.0 SOVERSION 4)
+
+########### install files ###############
+
+install(TARGETS ${LIB_FS_GANESHA} COMPONENT fsal DESTINATION  ${FSAL_DESTINATION} )
+
+# rpmbuild specific stuff
+set(CPACK_PACKAGE_FILE_NAME "${LIB_FS_GANESHA}-Source" )
+set(CPACK_PACKAGE_VENDOR "Seagate")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "NFS-Ganesha FSAL for ${PROJECT_NAME_BASE}-FS")
+SET(CPACK_PACKAGE_VERSION_MAJOR ${KVSFS_GANESHA_MAJOR_VERSION})
+SET(CPACK_PACKAGE_VERSION_MINOR ${KVSFS_GANESHA_MINOR_VERSION})
+SET(CPACK_PACKAGE_VERSION_PATCH ${KVSFS_GANESHA_PATCH_LEVEL})
+
+# Tell CPack the kind of packages to be generated
+set(CPACK_GENERATOR "TGZ")
+set(CPACK_SOURCE_GENERATOR "TGZ")
+
+set(CPACK_SOURCE_IGNORE_FILES
+  "/.git/;/.gitignore/;/build/;/.bzr/;~$;${CPACK_SOURCE_IGNORE_FILES}")
+
+include(CPack)
+
+set(PKG_NAME "${CPACK_PACKAGE_NAME}.tar.gz")
+add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
+
+# Now create a useable specfile
+configure_file(
+  "${PROJECT_SOURCE_DIR}/${LIB_FS_GANESHA}.spec-in.cmake"
+  "${PROJECT_SOURCE_DIR}/${LIB_FS_GANESHA}.spec"
+)
+
+set(RPM_BUILD_OPTIONS " --define '_srcrpmdir ${CMAKE_CURRENT_BINARY_DIR}' --define '_lib_path ${CMAKE_BINARY_DIR}' --define '_nfs_setup_dir ${CMAKE_SOURCE_DIR}/conf' ")
+
+add_custom_target( rpm DEPENDS dist)
+add_custom_command(TARGET rpm
+	COMMAND sh -c "rpmbuild ${RPM_BUILD_OPTIONS}  -tb ${CPACK_SOURCE_PACKAGE_FILE_NAME}.tar.gz"
+	VERBATIM
+	DEPENDS dist)
+
+# A quick check of the dependencies of the library
+add_custom_target(check_ldd DEPENDS ${LIB_FS_GANESHA})
+add_custom_command(TARGET check_ldd
+	COMMAND env LD_LIBRARY_PATH=${LIBCORTXFS} LD_PRELOAD=/usr/lib64/libganesha_nfsd.so /usr/bin/ldd -r ${CMAKE_BINARY_DIR}/${LIB_FS_GANESHA}.so
+	VERBATIM)
+

--- a/cortx-fs-ganesha/src/FSAL/FSAL_CORTXFS/fsal_global_tables.c
+++ b/cortx-fs-ganesha/src/FSAL/FSAL_CORTXFS/fsal_global_tables.c
@@ -1,0 +1,224 @@
+/**
+ * Filename:         fsal_global_tables.c
+ * Description:      FSAL CORTXFS's global table implementation related
+ *                   data structures and associated APIs
+ * Do NOT modify or remove this copyright and confidentiality notice!
+ * Copyright (c) 2020, Seagate Technology, LLC.
+ * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
+ * Portions are also trade secret. Any use, duplication, derivation,
+ * distribution or disclosure of this code, for any reason, not expressly
+ * authorized is prohibited. All other rights are expressly reserved by
+ * Seagate Technology, LLC.
+ * Author: Pratyush Kumar Khan <pratyush.k.khan@seagate.com>
+ */
+
+#include "config.h"
+
+#include <assert.h>
+#include <libgen.h>		/* used for 'dirname' */
+#include <pthread.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+#include <mntent.h>
+#include "gsh_list.h"
+#include "fsal.h"
+#include "fsal_internal.h"
+#include "fsal_convert.h"
+#include "FSAL/fsal_config.h"
+#include "FSAL/fsal_commonlib.h"
+#include "kvsfs_methods.h"
+#include "nfs_exports.h"
+#include "nfs_creds.h"
+#include "pnfs_utils.h"
+#include <stdbool.h>
+#include <arpa/inet.h>
+
+
+#define CORTXFS_HASH_TABLE_SIZE 64
+
+struct cortxfs_hash_elem {
+	uint16_t helm_ref; // TODO: implement it
+	void *helm;
+	size_t helm_size;
+	LIST_ENTRY(cortxfs_hash_elem) helm_link;
+};
+
+struct cortxfs_hash_bucket {
+	pthread_mutex_t hbt_mutex;
+	LIST_HEAD(hbt_list, cortxfs_hash_elem) hbt_chain;
+};
+
+struct cortxfs_hash_table {
+	struct cortxfs_hash_bucket ht_buckets[CORTXFS_HASH_TABLE_SIZE];
+};
+
+struct cortxfs_gtbl {
+	enum cortxfs_gtbl_types gt_type;
+	struct cortxfs_hash_table gt_ht;
+	/**
+	 * TODO: add private ctx and recall handler for async free
+	 * This will be needed when a HT elem (e.g. a layout) with non-zero
+	 * references are being removed. This removal should trigger the
+	 * associated table's recall handler, that handler will inform the
+	 * client that the active layout is being removed.
+	 */
+};
+
+static struct cortxfs_gtbl g_tbls[CORTXFS_GTBL_STATE_END];
+
+static void gtbl_htbl_ini(struct cortxfs_hash_table *ht)
+{
+	int rc;
+	int idx = 0;
+
+	memset(ht, 0, sizeof(*ht));
+
+	while (idx < CORTXFS_HASH_TABLE_SIZE) {
+		rc = pthread_mutex_init(&ht->ht_buckets[idx].hbt_mutex, NULL);
+		dassert(rc == 0);
+		idx++;
+	}
+}
+
+static void gtbl_htbl_fini(struct cortxfs_hash_table *ht)
+{
+	int rc;
+	int idx = 0;
+	struct cortxfs_hash_bucket *hbt;
+	struct cortxfs_hash_elem *helem;
+
+	memset(ht, 0, sizeof(*ht));
+
+	while (idx < CORTXFS_HASH_TABLE_SIZE) {
+		hbt = &ht->ht_buckets[idx];
+
+		while (!LIST_EMPTY(&hbt->hbt_chain)) {
+			helem = LIST_FIRST(&hbt->hbt_chain);
+			LIST_REMOVE(helem, helm_link);
+			// TODO: if helm_ref != 0, use recall/upcall/teardown
+			gsh_free(helem->helm);
+			gsh_free(helem);
+		}
+
+		rc = pthread_mutex_destroy(&ht->ht_buckets[idx].hbt_mutex);
+		dassert(rc == 0);
+		idx++;
+	}
+}
+
+void gtbl_ini(void)
+{
+	gtbl_htbl_ini(&g_tbls[CORTXFS_GTBL_STATE_LAYOUTS].gt_ht);
+	// TODO: add future tables here, one global for each type
+}
+
+void gtbl_fini(void)
+{
+	gtbl_htbl_fini(&g_tbls[CORTXFS_GTBL_STATE_LAYOUTS].gt_ht);
+	// TODO: add future tables here, one global for each type
+}
+
+int gtbl_add_elem(enum cortxfs_gtbl_types type, void *elem, size_t elem_size,
+		   uint64_t key)
+{
+	int rc, rc1 = 0;
+	struct cortxfs_hash_bucket *hbt;
+	struct cortxfs_hash_elem *helem;
+	uint16_t hkey = key % CORTXFS_HASH_TABLE_SIZE;
+
+	dassert(type >= CORTXFS_GTBL_STATE_END);
+	dassert(elem != NULL);
+
+	hbt = &g_tbls[type].gt_ht.ht_buckets[hkey];
+
+	rc = pthread_mutex_lock(&hbt->hbt_mutex);
+	dassert(rc == 0);
+
+	LIST_FOREACH(helem, &hbt->hbt_chain, helm_link) {
+		if ((helem->helm_size == elem_size) &&
+		    (memcmp(helem->helm, elem, elem_size) == 0)) {
+			// already present, do nothing
+			rc1 = EEXIST;
+			goto out;
+		}
+	}
+
+	helem = gsh_calloc(1, sizeof(*helem));
+	dassert(helem != NULL);
+	helem->helm = elem;
+	LIST_INSERT_HEAD(&hbt->hbt_chain, helem, helm_link);
+
+out:
+	rc = pthread_mutex_unlock(&hbt->hbt_mutex);
+	dassert(rc == 0);
+
+	return rc1;
+}
+
+void * gtbl_find_elem(enum cortxfs_gtbl_types type, const void *elem,
+			     size_t elem_size, uint64_t key)
+{
+	int rc;
+	void *elem_ret = NULL;
+	struct cortxfs_hash_bucket *hbt;
+	struct cortxfs_hash_elem *helem;
+	uint16_t hkey = key % CORTXFS_HASH_TABLE_SIZE;
+
+	dassert(type >= CORTXFS_GTBL_STATE_END);
+	dassert(elem != NULL);
+
+	hbt = &g_tbls[type].gt_ht.ht_buckets[hkey];
+
+	rc = pthread_mutex_lock(&hbt->hbt_mutex);
+	dassert(rc == 0);
+
+	LIST_FOREACH(helem, &hbt->hbt_chain, helm_link) {
+		if ((helem->helm_size == elem_size) &&
+		    (memcmp(helem->helm, elem, elem_size) == 0)) {
+			elem_ret = helem->helm;
+			break;
+		}
+	}
+
+	rc = pthread_mutex_unlock(&hbt->hbt_mutex);
+	dassert(rc == 0);
+
+	return elem_ret;
+}
+
+void * gtbl_remove_elem(enum cortxfs_gtbl_types type, const void *elem,
+			   size_t elem_size, uint64_t key)
+{
+	int rc;
+	void *elem_rmv = NULL;
+	struct cortxfs_hash_bucket *hbt;
+	struct cortxfs_hash_elem *helem;
+	uint16_t hkey = key % CORTXFS_HASH_TABLE_SIZE;
+
+	dassert(elem != NULL);
+
+	hbt = &g_tbls[type].gt_ht.ht_buckets[hkey];
+
+	rc = pthread_mutex_lock(&hbt->hbt_mutex);
+	dassert(rc == 0);
+
+	LIST_FOREACH(helem, &hbt->hbt_chain, helm_link) {
+		if ((helem->helm_size == elem_size) &&
+		    (memcmp(helem->helm, elem, elem_size) == 0)) {
+			elem_rmv = helem->helm;
+			break;
+		}
+	}
+
+	if (elem_rmv) {
+		LIST_REMOVE(helem, helm_link);
+		gsh_free(helem);
+	}
+
+	rc = pthread_mutex_unlock(&hbt->hbt_mutex);
+	dassert(rc == 0);
+
+	return elem_rmv;
+}

--- a/cortx-fs-ganesha/src/FSAL/FSAL_CORTXFS/fsal_internal.h
+++ b/cortx-fs-ganesha/src/FSAL/FSAL_CORTXFS/fsal_internal.h
@@ -1,0 +1,152 @@
+#ifndef _FSAL_INTERNAL_H
+#define _FSAL_INTERNAL_H
+
+#include "fsal.h" /* attributes */
+#include "kvsfs_methods.h"
+
+// forward declaration
+struct kvsfs_pnfs_mds_ctx;
+
+/* KVSFS FSAL module private storage
+ */
+
+struct kvsfs_fsal_module {
+	struct fsal_module fsal;
+	struct fsal_staticfsinfo_t fs_info;
+	struct fsal_obj_ops handle_ops;
+	/* pNFS related KVSFS FSAL's global config */
+	struct kvsfs_pnfs_mds_ctx *mds_ctx;
+};
+/** KVSFS-related data for a file state object. */
+struct kvsfs_file_state {
+	/** The open and share mode etc. */
+	fsal_openflags_t openflags;
+
+	/** The CORTXFS file descriptor. */
+	cfs_file_open_t cfs_fd;
+};
+fsal_status_t kvsfs_create_export(struct fsal_module *fsal_hdl,
+				void *parse_node,
+				struct config_error_type *err_type,
+				const struct fsal_up_vector *up_ops);
+
+void kvsfs_handle_ops_init(struct fsal_obj_ops *ops);
+struct kvsfs_fsal_obj_handle {
+	/* Base Handle */
+	struct fsal_obj_handle obj_handle;
+
+	/* CORTXFS Handle */
+	struct cfs_fh *handle;
+
+	/* TODO:EOS-3288
+	 * This field will removed and replaced
+	 * by a call to struct cfs_fh
+	 */
+	/* CORTXFS Context */
+	struct cfs_fs *cfs_fs;
+
+	/* Global state is disabled because we don't support NFv3. */
+	/* struct kvsfs_file_state global_fd; */
+
+	/* Share reservations */
+	struct fsal_share share;
+};
+
+/* Returns a vtable that implements the ::cfs_endpoint_ops
+ * interface for the NFS Ganesha (/etc/ganesha/ganesha.conf) config file.
+ */
+const struct cfs_endpoint_ops *kvsfs_config_ops(void);
+
+/* linkage to the exports and handle ops initializers
+ */
+
+struct kvsfs_ds {
+	struct fsal_ds_handle ds; /*< Public DS handle */
+	struct kvsfs_file_handle wire; /*< Wire data */
+	struct kvsfs_filesystem *kvsfs_fs; /*< Related kvsfs filesystem */
+	bool connected; /*< True if the handle has been connected */
+};
+
+#if 0
+static inline size_t kvsfs_sizeof_handle(struct kvsfs_file_handle *hdl)
+{
+	return (size_t) sizeof(struct kvsfs_file_handle);
+}
+
+/* the following variables must not be defined in fsal_internal.c */
+#ifndef FSAL_INTERNAL_C
+
+/* static filesystem info.
+ * read access only.
+ */
+extern struct fsal_staticfsinfo_t global_fs_info;
+
+#endif
+#endif
+
+/* KVSFS methods for pnfs
+ */
+
+int kvsfs_pmds_ini(struct kvsfs_fsal_module *kvsfs,
+		   const struct config_item *kvsfs_params);
+int kvsfs_pmds_fini(struct kvsfs_fsal_module *kvsfs);
+int kvsfs_pmds_update_exp(struct kvsfs_fsal_module *kvsfs,
+			  const struct kvsfs_fsal_export *exp_config);
+nfsstat4 kvsfs_getdeviceinfo(struct fsal_module *fsal_hdl,
+			      XDR *da_addr_body,
+			      const layouttype4 type,
+			      const struct pnfs_deviceid *deviceid);
+
+size_t kvsfs_fs_da_addr_size(struct fsal_module *fsal_hdl);
+void export_ops_pnfs(struct export_ops *ops);
+void handle_ops_pnfs(struct fsal_obj_ops *ops);
+void kvsfs_pnfs_ds_ops_init(struct fsal_pnfs_ds_ops *ops);
+
+enum cortxfs_gtbl_types {
+	CORTXFS_GTBL_CLIENT = 0,
+	CORTXFS_GTBL_STATE_OPEN,
+	CORTXFS_GTBL_STATE_BR_LOCKS,
+	CORTXFS_GTBL_STATE_DELEGS,
+	CORTXFS_GTBL_STATE_LAYOUTS,
+	CORTXFS_GTBL_STATE_END
+};
+
+/**
+ * Initialize the CORTXFS FSAL's global tables
+ */
+void gtbl_ini(void);
+
+/**
+ * Free the CORTXFS FSAL's global tables
+ */
+void gtbl_fini(void);
+
+/**
+ * Add an entry to CORTXFS FSAL's global table
+ * Caller must pass pre-allocated elem
+ * Returns 0 if success, else error code
+ */
+int gtbl_add_elem(enum cortxfs_gtbl_types type, void *elem,
+		   size_t elem_size, uint64_t key);
+
+/**
+ * Find an entry in CORTXFS FSAL's global table
+ * Caller must not free elem
+ */
+void * gtbl_find_elem(enum cortxfs_gtbl_types type, const void *elem,
+		      size_t elem_size, uint64_t key);
+
+/**
+ * Free an entry from CORTXFS FSAL's global table
+ * Returns NULL if not found
+ * Caller must free elem
+ */
+void * gtbl_remove_elem(enum cortxfs_gtbl_types type, const void *elem,
+			size_t elem_size, uint64_t key);
+
+/**
+ * Call this API when a layout on a file handle is being returned/freed
+ */
+void gtbl_layout_rmv_elem(const struct kvsfs_file_handle *lt_fh);
+
+#endif /* _FSAL_INTERNAL_H */

--- a/cortx-fs-ganesha/src/FSAL/FSAL_CORTXFS/handle.c
+++ b/cortx-fs-ganesha/src/FSAL/FSAL_CORTXFS/handle.c
@@ -1,0 +1,3031 @@
+/*
+ * vim:noexpandtab:shiftwidth=8:tabstop=8:
+ *
+ * Copyright (C) Panasas Inc., 2011
+ * Author: Jim Lieb jlieb@panasas.com
+ *
+ * contributeur : Philippe DENIEL   philippe.deniel@cea.fr
+ *                Thomas LEIBOVICI  thomas.leibovici@cea.fr
+ *
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ *
+ * -------------
+ */
+
+/* TODOs in this module:
+	- TODO:EOS-1479:
+		Special stateid handling.
+	- TODO:EOS-914:
+		Truncate op implementation.
+	- TODO:PERF:
+		Performance improvements.
+	- TODO:PORTING:
+		Things which we will need to implement, but right now
+		we can live without them. For instance, reopen2 which
+		makes no sense without share reservation feature implemented.
+*/
+
+/* File States and File Handle.
+ *  A file handle is the concept from NFSv3 where a file has a unique identifier
+ *  used for various operations like READ/WRITE/LOOKUP etc. In our FSAL
+ *  a file handle is just the inode of a file.
+ *  NFSv4+ introduces a new concept of state (stateid) : the server side have to
+ *  manage not only the filehandles within a filesystem, but also their states.
+ *  In NFS Ganesha file states are represented by ::state_t structure while
+ *  file handles are represented by ::fsal_obj_handle structure.
+ *  Corresponddingly, the FSAL defines ::kvsfs_obj_handle and ::kvsfs_state_fd.
+ *
+ *  Right now KVSFS does not strore any information about file states in the
+ *  KVS backend (i.e., does not call cfs_open/close). Those calls will be
+ *  implemented in the scope of the corresponding IO-related tickets.
+ *
+ *  File States and Open/Close implementation must be revisited when we add
+ *  our own recovery engine.
+ */
+
+/******************************************************************************/
+#include "kvsfs_methods.h"
+#include "fsal_internal.h" /* kvsfs_fsal_module */
+#include <gsh_list.h> /* container_of */
+#include <fsal_convert.h> /* posix2fsal */
+#include <FSAL/fsal_commonlib.h> /* FSAL methods */
+#include <cortxfs_fh.h>
+#include <nfs_exports.h> /* EXPORT_OPTION_DISABLE_ACL */
+#include <debug.h>	/* dassert */
+
+#include <../FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_int.h>
+#include <../FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_hash.h>
+
+/******************************************************************************/
+/* Internal data types */
+
+/** KVSFS version of a file state object.
+ * @see kvsfs_alloc_state and kvsfs_free_state.
+ */
+struct kvsfs_state_fd {
+	/* base */
+	struct state_t state;
+	/* data */
+	struct kvsfs_file_state kvsfs_fd;
+};
+static inline cfs_ino_t *
+kvsfs_fh_to_ino(struct cfs_fh *kvsfs_fh)
+{
+	return cfs_fh_ino(kvsfs_fh);
+}
+
+/******************************************************************************/
+/* Wrappers for KVSFS handle debug traces. Enable this "#if" if you want
+ * to get traces even without enabled DEBUG logging level, i.e. if you want to
+ * see only debug logs from this module.
+ */
+#if 1
+#define T_ENTER(_fmt, ...) \
+	LogCrit(COMPONENT_FSAL, "T_ENTER " _fmt, __VA_ARGS__)
+
+#define T_EXIT(_fmt, ...) \
+	LogCrit(COMPONENT_FSAL, "T_EXIT " _fmt, __VA_ARGS__)
+
+#define T_TRACE(_fmt, ...) \
+	LogCrit(COMPONENT_FSAL, "T_TRACE " _fmt, __VA_ARGS__)
+#else
+#define T_ENTER(_fmt, ...) \
+	LogDebug(COMPONENT_FSAL, "T_ENTER " _fmt, __VA_ARGS__)
+
+#define T_EXIT(_fmt, ...) \
+	LogDebug(COMPONENT_FSAL, "T_EXIT " _fmt, __VA_ARGS__)
+
+#define T_TRACE(_fmt, ...) \
+	LogDebug(COMPONENT_FSAL, "T_TRACE " _fmt, __VA_ARGS__)
+#endif
+
+#define T_ENTER0 T_ENTER(">>> %s", "()");
+#define T_EXIT0(__rcval)  T_EXIT("<<< rc=%d", __rcval);
+
+/* The name of the ACL extended attribute in CORTXFS */
+static const char* ACL_XATTR_NAME = "nfs.acl";
+
+/* Enable/Disable the ACL functionality with the ganesha conf parameter. */
+static inline bool kvsfs_is_acl_enabled()
+{
+	return (!op_ctx_export_has_option(EXPORT_OPTION_DISABLE_ACL));
+}
+
+/******************************************************************************/
+/* Global variable imported from main.c */
+extern struct kvsfs_fsal_module KVSFS;
+
+/******************************************************************************/
+/* TODO:
+ * Function is deprecated after EOS-3288 is complitely done.
+ */
+static void construct_handle(struct fsal_export *export_base,
+			     const cfs_ino_t *ino,
+			     const struct stat *stat,
+			     struct fsal_obj_handle **obj)
+{
+	int rc;
+	struct kvsfs_fsal_obj_handle *result;
+	struct kvsfs_fsal_export *export =
+	    container_of(op_ctx->fsal_export, struct kvsfs_fsal_export, export);
+
+	result = gsh_calloc(1, sizeof(*result));
+
+	/* A workaround to keep backward compatibilty:
+	 * "construct_handle" was not designed to return an error code,
+	 * so that in case of ENOMEM, we will just abort the program
+	 * in the same as gsh_calloc() aborts execution if there is
+	 * not enough memory.
+	 */
+	rc = cfs_fh_from_ino(export->cfs_fs, ino, stat, &result->handle);
+	if (rc < 0) {
+		LogCrit(COMPONENT_FSAL, "Failed to create FH, rc: %d", rc);
+		abort();
+	}
+
+	result->cfs_fs = export->cfs_fs;
+
+	fsal_obj_handle_init(&result->obj_handle,
+			     export_base,
+			     posix2fsal_type(stat->st_mode));
+
+	result->obj_handle.fsid.major = export->fs_id;
+	result->obj_handle.fsid.minor = 0;
+	result->obj_handle.fileid = stat->st_ino;
+
+	result->obj_handle.obj_ops = &KVSFS.handle_ops;
+
+	*obj = &result->obj_handle;
+
+	T_TRACE("Constructed handle: %p, INO: %d, FSID: %d:%d, FILEID: %d",
+		*obj, (int) *ino,
+		(int) result->obj_handle.fsid.major,
+		(int) result->obj_handle.fsid.minor,
+		(int) result->obj_handle.fileid);
+}
+
+/** Creates a new KVSFS File Handle using a CORTXFS File handle.
+ * The function allocates and initializes a KVSFS FSAL FH using
+ * an existing CORTXFS Fh.
+ * Note: It moves CORTXFS FH into KVSFS FH and sets the pointer to
+ * NULL -- it prevents consequent calls from directly accessing
+ * CORTXFS FH which is now a part of KVSFS FH.
+ */
+static void fsal_obj_handle_from_cfs_fh(struct fsal_export *export_base,
+					struct cfs_fh **pfh,
+					struct fsal_obj_handle **obj)
+{
+	struct kvsfs_fsal_obj_handle *result;
+	struct cfs_fh *fh = *pfh;
+	struct kvsfs_fsal_export *export =
+	    container_of(op_ctx->fsal_export, struct kvsfs_fsal_export, export);
+	struct stat *stat = cfs_fh_stat(fh);
+
+	result = gsh_calloc(1, sizeof(*result));
+
+	result->handle = fh;
+	result->cfs_fs = export->cfs_fs;
+
+	fsal_obj_handle_init(&result->obj_handle,
+			     export_base,
+			     posix2fsal_type(stat->st_mode));
+
+	/* TODO: We shoud not dynamically assign the FSID defined
+	 * in the export config, and use stat->st_dev, i.e.:
+	 *	result->obj_handle.fsid = posix2fsal_fsid(stat->st_dev);
+	 * It is required to make sure that all file objects in all
+	 * frontends have the correct fsid attribute.
+	 * However, right now FSID is not propogated to stat->st_dev,
+	 * so that we cannot use it.
+	 */
+	result->obj_handle.fsid.major = export->fs_id;
+	result->obj_handle.fsid.minor = 0;
+	result->obj_handle.fileid = stat->st_ino;
+
+	result->obj_handle.obj_ops = &KVSFS.handle_ops;
+
+	*obj = &result->obj_handle;
+	*pfh = NULL; /* moved into the result */
+
+	T_TRACE("Constructed KVSFS FH: %p, INO: %d, FSID: %d:%d, FILEID: %d",
+		*obj, (int) *cfs_fh_ino(fh),
+		(int) result->obj_handle.fsid.major,
+		(int) result->obj_handle.fsid.minor,
+		(int) result->obj_handle.fileid);
+}
+
+/******************************************************************************/
+/* Checks if a KVSFS File Handle is open.
+ * NOTE: It works only with files passed by NFS Ganesha from the MDCACHE.
+ * A file handle created by a kvsfs_lookup call won't show the correct state.
+ */
+static bool kvsfs_fh_is_open(struct kvsfs_fsal_obj_handle *obj)
+{
+	static const struct fsal_share empty_share = {0};
+	return (memcmp(&empty_share, &obj->share, sizeof(empty_share)) != 0);
+}
+
+/******************************************************************************/
+/* FSAL.lookup */
+static fsal_status_t kvsfs_lookup(struct fsal_obj_handle *parent_hdl,
+				  const char *name,
+				  struct fsal_obj_handle **handle,
+				  struct attrlist *attrs_out)
+{
+	struct kvsfs_fsal_obj_handle *parent;
+	int rc = 0;
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+	struct cfs_fh *object = NULL;
+	struct kvsfs_fsal_export *export =
+	    container_of(op_ctx->fsal_export, struct kvsfs_fsal_export, export);
+
+	T_ENTER(">>> (%p, %s)", parent_hdl, name);
+
+	assert(name);
+	assert(strlen(name) > 0);
+
+	if (!fsal_obj_handle_is(parent_hdl, DIRECTORY)) {
+		LogCrit(COMPONENT_FSAL,
+			"Parent handle (%p) is not a directory.", parent_hdl);
+		rc = -ENOTDIR;
+		goto out;
+	}
+
+	parent = container_of(parent_hdl, struct kvsfs_fsal_obj_handle,
+			     obj_handle);
+
+	rc = cfs_fh_lookup(&cred, parent->handle, name, &object);
+
+	if (rc < 0) {
+		goto out;
+	}
+
+	if (attrs_out != NULL) {
+		posix2fsal_attributes_all(cfs_fh_stat(object), attrs_out);
+	}
+
+	fsal_obj_handle_from_cfs_fh(op_ctx->fsal_export, &object, handle);
+
+ out:
+	if (object) {
+		cfs_fh_destroy(object);
+	}
+	T_EXIT0(-rc);
+	return fsalstat(posix2fsal_error(-rc), -rc);
+}
+
+/******************************************************************************/
+/* FSAL.looup_path - Find Inode of Export Root */
+fsal_status_t kvsfs_lookup_path(struct fsal_export *exp_hdl,
+			       const char *path,
+			       struct fsal_obj_handle **handle,
+			       struct attrlist *attrs_out)
+{
+	int rc = 0;
+	struct cfs_fh *object = NULL;
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+	struct kvsfs_fsal_export *myexport;
+
+	T_ENTER(" >> (%p, %s)", exp_hdl, path);
+	assert(exp_hdl);
+
+	myexport = container_of(op_ctx->fsal_export,
+				struct kvsfs_fsal_export, export);
+
+	rc = cfs_fh_getroot(myexport->cfs_fs, &cred, &object);
+	if (rc != 0) {
+		goto out;
+	}
+
+	if (attrs_out != NULL) {
+		posix2fsal_attributes_all(cfs_fh_stat(object), attrs_out);
+	}
+
+	fsal_obj_handle_from_cfs_fh(op_ctx->fsal_export, &object, handle);
+
+out:
+	if (object) {
+		cfs_fh_destroy(object);
+	}
+	T_EXIT0(-rc);
+	return fsalstat(posix2fsal_error(-rc), -rc);
+}
+
+static int kvsfs_acl_entries_to_xattr(uint32_t naces, fsal_ace_t *aces,
+				      void *buf, size_t buflen)
+{
+	void *offset_ptr = NULL;
+	int rc = 0;
+
+	dassert(buf != NULL);
+	dassert(aces != NULL);
+	dassert(buflen == naces * sizeof(*aces) + sizeof(naces));
+
+	if (buflen > CFS_XATTR_SIZE_MAX) {
+		rc = -ERANGE;
+		goto out;
+	}
+
+	if ((naces == 0) || (buflen == 0)) {
+		rc = -EINVAL;
+		goto out;
+	}
+
+	offset_ptr = buf;
+	memcpy(offset_ptr, &naces, sizeof(naces));
+	offset_ptr = offset_ptr + sizeof(naces);
+	memcpy(offset_ptr, aces, buflen - sizeof(naces));
+out:
+	T_TRACE("buf = %p, buflen=%zu, aces=%p, naces=%"PRIu32", rc=%d",
+		buf, buflen, aces, naces, rc);
+	return rc;
+}
+
+static fsal_status_t kvsfs_setacl(struct kvsfs_fsal_obj_handle *obj,
+				  cfs_cred_t *cred, fsal_acl_t *acl)
+{
+	void *buf = NULL;
+	int rc;
+	uint32_t naces;
+	size_t buflen;
+	fsal_status_t status;
+
+	T_TRACE( ">> Enter obj=%p, acl=%p", obj, acl);
+
+	/* There are no more acl entries for these file/dir. Delete the acl.*/
+	if (!acl) {
+		T_TRACE("Deleting the ACL for %p", obj);
+		rc = cfs_removexattr(obj->cfs_fs, cred,
+				     kvsfs_fh_to_ino(obj->handle),
+				     ACL_XATTR_NAME);
+		/* Having no ACL is not a crime. */
+		if (rc == -ENOENT) {
+			rc = 0;
+		}
+		goto out;
+	}
+
+	fsal_print_acl(COMPONENT_FSAL, NIV_DEBUG, acl);
+	naces = acl->naces;
+	if (naces == 0) {
+		rc = 0;
+		T_TRACE("%s", "No ACEs to be set");
+		goto out;
+	}
+
+	buflen = naces * sizeof(fsal_ace_t) + sizeof(acl->naces);
+	if (buflen > CFS_XATTR_SIZE_MAX) {
+		rc = -ERANGE;
+		LogCrit(COMPONENT_FSAL, "ACL too large! obj = %p, size = %zu",
+			obj, buflen);
+		goto out;
+	}
+
+	buf = gsh_malloc(buflen);
+
+	/* Serialize the aces into xattr buffer */
+	rc = kvsfs_acl_entries_to_xattr(naces, acl->aces, buf, buflen);
+	if (rc != 0) {
+		LogCrit(COMPONENT_FSAL,
+			"ACL to xattr serialization failed, obj=%p, rc=%d",
+                        obj, rc);
+		goto out;
+	}
+
+	rc  = cfs_setxattr(obj->cfs_fs, cred,
+			     kvsfs_fh_to_ino(obj->handle), ACL_XATTR_NAME,
+		             buf, buflen, 0);
+
+out:
+	gsh_free(buf);
+	T_EXIT("Exit, rc = %d", rc);
+	return fsalstat(posix2fsal_error(-rc), -rc);
+}
+
+/******************************************************************************/
+/* FSAL.mkdir - Create a directory */
+static fsal_status_t kvsfs_mkdir(struct fsal_obj_handle *dir_hdl,
+				const char *name, struct attrlist *attrs_in,
+				struct fsal_obj_handle **handle,
+				struct attrlist *attrs_out)
+{
+	struct kvsfs_fsal_obj_handle *myself, *hdl;
+	int retval = 0;
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+	cfs_ino_t object;
+	struct stat stat;
+	mode_t unix_mode;
+	fsal_status_t status = fsalstat(ERR_FSAL_NO_ERROR, 0);
+	struct attrlist parent_attrs = {0};
+
+	/* TODO:PERF: Check if it can be converted into an assert pre-cond */
+	if (!fsal_obj_handle_is(dir_hdl, DIRECTORY)) {
+		LogCrit(COMPONENT_FSAL,
+			"Parent handle is not a directory. hdl = 0x%p",
+			dir_hdl);
+		retval = -ENOTDIR;
+		goto out;
+	}
+
+	myself = container_of(dir_hdl, struct kvsfs_fsal_obj_handle,
+			      obj_handle);
+
+	unix_mode = fsal2unix_mode(attrs_in->mode)
+		& ~op_ctx->fsal_export->exp_ops.fs_umask(op_ctx->fsal_export);
+
+	retval = cfs_mkdir(myself->cfs_fs, &cred,
+			   kvsfs_fh_to_ino(myself->handle),
+			   (char *) name, unix_mode, &object);
+	if (retval < 0) {
+		status = fsalstat(posix2fsal_error(-retval), -retval);
+		goto out;
+	}
+
+	retval = cfs_getattr(myself->cfs_fs, &cred, &object, &stat);
+	if (retval < 0) {
+		/* XXX:
+		 * We have created a directory but cannot get its attributes
+		 * What should we do here? remove it?
+		 *
+		 * TODO:PERF:
+		 * cfs_mkdir must return the stats of the created
+		 * directory so that we can avoid this cfs_getattr call.
+		 */
+		status = fsalstat(posix2fsal_error(-retval), -retval);
+		goto out;
+	}
+
+	construct_handle(op_ctx->fsal_export, &object, &stat, handle);
+
+	if (attrs_out != NULL) {
+		posix2fsal_attributes_all(&stat, attrs_out);
+	}
+
+	if (kvsfs_is_acl_enabled()) {
+		/* @TODO:
+		 *  Add access checks here for checking if the caller
+                 *  has permission to set the ACL. This would be added after
+		 *  access checks using ACLs are implemented.
+		 */
+
+		/* Try to get ACL of the parent directory, and set them
+                   on the child directory. */
+		fsal_prepare_attrs(&parent_attrs, ATTR_ACL);
+		status = dir_hdl->obj_ops->getattrs(dir_hdl, &parent_attrs);
+		if (FSAL_IS_ERROR(status)) {
+		        /* XXX We are not able to fetch attributes of the
+			 * parent directory. What should we do here?
+			 */
+			LogCrit(COMPONENT_FSAL,
+				"Failed to fetch parent dir %p attrs!",
+				dir_hdl);
+			goto out;
+
+		}
+		status.major = fsal_inherit_acls(attrs_in, parent_attrs.acl,
+					         FSAL_ACE_FLAG_DIR_INHERIT);
+		if (FSAL_IS_ERROR(status)) {
+		        T_TRACE("Failed to inherit parent dir %p acl", dir_hdl);
+			goto free_attrs;
+		}
+		hdl = container_of(*handle, struct kvsfs_fsal_obj_handle,
+			            obj_handle);
+		status = kvsfs_setacl(hdl, &cred, attrs_in->acl);
+			if (FSAL_IS_ERROR(status)) {
+				LogCrit(COMPONENT_FSAL,
+				        "Set acl on dir %p failed", hdl);
+				 goto free_attrs;
+		}
+	} /* if (kvsfs_is_acl_enabled()) */
+
+free_attrs:
+	fsal_release_attrs(&parent_attrs);
+
+out:
+	T_EXIT0(status.major);
+	return status;
+}
+
+/** makesymlink
+ *  Note that we do not set mode bits on symlinks for Linux/POSIX
+ *  They are not really settable in the kernel and are not checked
+ *  anyway (default is 0777) because open uses that target's mode.
+ *  @see ::CORTXFS_SYMLINK_MODE.
+ */
+
+static fsal_status_t kvsfs_makesymlink(struct fsal_obj_handle *dir_hdl,
+				       const char *name, const char *link_path,
+				       struct attrlist *attrib,
+				       struct fsal_obj_handle **handle,
+				       struct attrlist *attrs_out)
+{
+	struct kvsfs_fsal_obj_handle *myself, *hdl;
+	int retval = 0;
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+	cfs_ino_t object;
+	struct stat stat;
+	struct fsal_obj_handle *new_hdl = NULL;
+	fsal_status_t status = fsalstat(ERR_FSAL_NO_ERROR, 0);
+
+	if (!fsal_obj_handle_is(dir_hdl, DIRECTORY)) {
+		LogCrit(COMPONENT_FSAL,
+			"Parent handle is not a directory. hdl = 0x%p",
+			dir_hdl);
+		status = fsalstat(ERR_FSAL_NOTDIR, ENOTDIR);
+		goto out;
+	}
+
+	myself = container_of(dir_hdl, struct kvsfs_fsal_obj_handle,
+			      obj_handle);
+
+	retval = cfs_symlink(myself->cfs_fs, &cred,
+			     kvsfs_fh_to_ino(myself->handle),
+			     (char *)name, (char *)link_path, &object);
+	if (retval < 0) {
+		status = fsalstat(posix2fsal_error(-retval), -retval);
+		goto out;
+	}
+
+	retval = cfs_getattr(myself->cfs_fs, &cred, &object, &stat);
+	if (retval < 0) {
+		status = fsalstat(posix2fsal_error(-retval), -retval);
+		goto out;
+	}
+
+	construct_handle(op_ctx->fsal_export, &object, &stat, &new_hdl);
+
+	/* The caller might want to set something except 'mode' */
+	if (FSAL_TEST_MASK(attrib->valid_mask, ATTR_MODE)) {
+		FSAL_UNSET_MASK(attrib->valid_mask, ATTR_MODE);
+
+		if (attrib->valid_mask) {
+			status = new_hdl->obj_ops->setattr2(new_hdl, false,
+							    NULL, attrib);
+			if (FSAL_IS_ERROR(status)) {
+				/* Revert attrib back and go out */
+				LogCrit(COMPONENT_FSAL,
+					"Failed to setattr2, status=%s",
+					fsal_err_txt(status));
+				FSAL_SET_MASK(attrib->valid_mask, ATTR_MODE);
+				goto out;
+			}
+		} else {
+			status = fsalstat(ERR_FSAL_NO_ERROR, 0);
+
+			if (attrs_out != NULL) {
+				/* Since we haven't set any attributes other than what
+				 * was set on create, just use the stat results we used
+				 * to create the fsal_obj_handle.
+				 */
+				posix2fsal_attributes_all(&stat, attrs_out);
+			}
+		}
+
+		FSAL_SET_MASK(attrib->valid_mask, ATTR_MODE);
+	}
+
+	/* Hand it over to the caller */
+	*handle = new_hdl;
+	new_hdl = NULL;
+
+out:
+	/* Release the handle if we haven't transfered it to the caller */
+	if (new_hdl) {
+		new_hdl->obj_ops->release(new_hdl);
+	}
+
+	return status;
+}
+
+/******************************************************************************/
+/* FSAL.realink */
+static fsal_status_t kvsfs_readsymlink(struct fsal_obj_handle *obj_hdl,
+				      struct gsh_buffdesc *link_content,
+				      bool refresh)
+{
+	struct kvsfs_fsal_obj_handle *myself = NULL;
+	int retval = 0;
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+
+	if (!fsal_obj_handle_is(obj_hdl, SYMBOLIC_LINK)) {
+		retval = -EINVAL; /* See RFC7530, 16.25.5 */
+		goto out;
+	}
+
+	myself = container_of(obj_hdl, struct kvsfs_fsal_obj_handle,
+			      obj_handle);
+
+	/* TODO:PERF:
+	 * We are allocating a 4K buffer here. We should not allocate it every
+	 * time.
+	 * See additional details here: EOS-259.
+	 */
+	link_content->len = fsal_default_linksize;
+	link_content->addr = gsh_malloc(link_content->len);
+
+	retval = cfs_readlink(myself->cfs_fs, &cred,
+			      kvsfs_fh_to_ino(myself->handle),
+			      link_content->addr, &link_content->len);
+
+	if (retval < 0) {
+		gsh_free(link_content->addr);
+		link_content->addr = NULL;
+		link_content->len = 0;
+		goto out;
+	}
+
+	/* NFS Ganesha requires the content buffer to be a NULL-terminated
+	 * string. Let's try to null-terminate it.
+	 * If the string len is 4K then we will just truncate it in the same
+	 * way as readlink(2) truncates the output buffer.
+	 */
+	if (link_content->len == fsal_default_linksize) {
+		/* truncate and append null */
+		((char *) link_content->addr)[link_content->len - 1] = '\0';
+	} else {
+		/* append null */
+		((char *) link_content->addr)[link_content->len] = '\0';
+		link_content->len++;
+	}
+
+ out:
+	return fsalstat(posix2fsal_error(-retval), -retval);
+}
+
+/******************************************************************************/
+/* FSAL.link */
+static fsal_status_t kvsfs_linkfile(struct fsal_obj_handle *obj_hdl,
+				    struct fsal_obj_handle *destdir_hdl,
+				    const char *name)
+{
+	struct kvsfs_fsal_obj_handle *myself;
+	struct kvsfs_fsal_obj_handle *destdir;
+	int retval = 0;
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+
+	myself = container_of(obj_hdl, struct kvsfs_fsal_obj_handle,
+			      obj_handle);
+
+	destdir = container_of(destdir_hdl, struct kvsfs_fsal_obj_handle,
+			       obj_handle);
+
+	retval = cfs_link(destdir->cfs_fs, &cred,
+			  kvsfs_fh_to_ino(myself->handle),
+			  kvsfs_fh_to_ino(destdir->handle),
+			  (char *) name);
+
+	return fsalstat(posix2fsal_error(-retval), -retval);
+}
+
+/******************************************************************************/
+/* FSAL.readdir */
+
+/** State (context) for kvsfs_readdir_cb.
+ * The callback is called when the current postion ("where") >= the start
+ * position ("whence").
+ * eof and dir_continue flags are cleared when iteractions were iterrupted
+ * by the user (nfs-ganesha).
+ * */
+struct kvsfs_readdir_cb_ctx {
+	/** READDIR starts from offset specified by "whence". */
+	const fsal_cookie_t whence;
+	/** nfs-ganesha callback which is called for each dir entry. */
+	const fsal_readdir_cb fsal_cb;
+	/** Current offset (index of "where" we are right now). */
+	fsal_cookie_t where;
+	/** Context for the nfs-ganesha callback. */
+	void *fsal_cb_ctx;
+	/** The flag is set to False when nfs-ganesha requested termination
+	 * of readdir procedure.
+	 */
+	bool dir_continue;
+	/** Flag is set to False when readdir was terminated and didn't
+	 * reach the last dir entry.
+	 */
+	bool eof;
+
+	attrmask_t attrmask;
+	int inner_rc;
+
+	struct kvsfs_fsal_obj_handle *parent;
+};
+
+#define KVSFS_FIRST_COOKIE 3
+
+/** A callback to be called for each READDIR entry.
+ * @param[in, out] ctx  - Callback state (context).
+ * @param[in]      name - Name of the dentry.
+ * @param[in]      stat - stat attributes of particular dentry to be used in
+ *                        callback
+ * @retval true if more entries are requested.
+ * @retval false if iterations must be interrupted.
+ * @see populate_dirent in nfs-ganesha.
+*/
+static bool kvsfs_readdir_cb(void *ctx, const char *name,
+                             const struct stat *stat)
+{
+	bool retval;
+	struct kvsfs_readdir_cb_ctx *cb_ctx = ctx;
+	enum fsal_dir_result dir_res;
+	struct attrlist attrs;
+	struct fsal_obj_handle *obj;
+	cfs_ino_t child_ino = stat->st_ino;
+	cfs_cred_t cred  = CFS_CRED_INIT_FROM_OP;
+
+	assert(cb_ctx != NULL);
+	assert(name != NULL);
+
+	T_ENTER("dentry[%d]=%s, ino=%llu", (int)cb_ctx->where, name,
+		(int)child_ino);
+	/* A small state machine for dir_continue and eof logic:
+	 * even if cb_ctx->fsal_cb returned false, we still have to
+	 * check if it was the last dir entry.
+	 * TODO:PERF: Add "unlikely" wrapper here.
+	 */
+	if (!cb_ctx->dir_continue) {
+		cb_ctx->eof = false;
+		T_EXIT("%s", "USER_CANCELED");
+		retval = false;
+		goto err_out;
+	}
+
+	if (cb_ctx->where < cb_ctx->whence) {
+		cb_ctx->where++;
+		T_EXIT("%s", "SKIP");
+		retval = true;
+		goto err_out;
+	}
+
+	fsal_prepare_attrs(&attrs, cb_ctx->attrmask);
+
+	construct_handle(op_ctx->fsal_export, &child_ino, stat, &obj);
+	posix2fsal_attributes_all(stat, &attrs);
+
+	T_TRACE("READDIR_CB: %s, %p, %d", name, obj, (int) cb_ctx->where);
+
+	dir_res = cb_ctx->fsal_cb(name, obj, &attrs, cb_ctx->fsal_cb_ctx,
+				  cb_ctx->where);
+
+	fsal_release_attrs(&attrs);
+
+	cb_ctx->dir_continue = (dir_res == DIR_CONTINUE);
+
+	cb_ctx->where++;
+
+	T_EXIT("NEED_NEXT %d, %d", (int) cb_ctx->dir_continue, (int) dir_res);
+	retval = true;
+
+err_out:
+	return retval;
+}
+
+static fsal_status_t kvsfs_readdir(struct fsal_obj_handle *dir_hdl,
+				  fsal_cookie_t *whence, void *dir_state,
+				  fsal_readdir_cb cb, attrmask_t attrmask,
+				  bool *eof)
+
+{
+	struct kvsfs_fsal_obj_handle *obj;
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+	struct kvsfs_readdir_cb_ctx readdir_ctx = {
+		/* If whence is NULL, it means we should start from the very
+		 * beginning (dentry[0]).
+		 * Othwerwise, it indicates the index of the dentry
+		 * (dentry[N]) followed by the dentry (dentry[N+1]) we should
+		 * pass to the callback.
+		 */
+		.whence = whence ? ((*whence) + 1) : KVSFS_FIRST_COOKIE,
+		.where = KVSFS_FIRST_COOKIE,
+		.fsal_cb = cb,
+		.fsal_cb_ctx = dir_state,
+		.eof = true,
+		.dir_continue = true,
+		.attrmask = attrmask,
+		.parent = NULL,
+		.inner_rc = 0,
+	};
+
+	struct cfs_fs *cfs_fs = NULL;
+	int rc;
+
+	obj = container_of(dir_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+
+	T_ENTER("parent=%d", (int) *kvsfs_fh_to_ino(obj->handle));
+
+	cfs_fs = obj->cfs_fs;
+	readdir_ctx.parent = obj;
+
+	/* NOTE:PERF:
+	 *	The current version of nfs-ganesha calls fsal_readdir()
+	 *	to update its internal inode cache. It fills the cache,
+	 *	and only after that returns a response to the client.
+	 *	Also, it calls lookup() and getattr() for each entry.
+	 *	Moreover, nfs-ganesha never uses whence != 0.
+	 *	Considering the above statements, there is no need to
+	 *	use the previous opendir/readdir-by-offset/closedir
+	 *	approach -- we can freely just walk over the whole directory.
+	 */
+	/* NOTE: nfs-ganesha migration.
+	 *	The recent version of nfs-ganesha has a mdcache FSAL instead
+	 *	of the inode cache. It looks like the MD FSAL is able to update
+	 *	only parts (chunks) of readdir contents depending on
+	 *	the state of L1 LRU and L2 MRU caches.
+	 *	Moreover, the new version supports a whence-as-name export
+	 *	option which allows to use filenames as offsets (see RGW FSAL).
+	 *	Therefore, the readdir cortxfs interface can be extened
+	 *	to support a start dir entry name as an option.
+	 *	Also, the new version will requite readdir_cb to call
+	 *	getattr().
+	 */
+	rc = cfs_readdir(cfs_fs, &cred, kvsfs_fh_to_ino(obj->handle),
+			 kvsfs_readdir_cb, &readdir_ctx);
+
+	if (rc < 0)
+		goto out;
+
+	if (readdir_ctx.inner_rc != 0 ) {
+		rc = readdir_ctx.inner_rc;
+		goto out;
+	}
+
+	*eof = readdir_ctx.eof;
+
+ out:
+	T_EXIT0(-rc);
+	return fsalstat(posix2fsal_error(-rc), -rc);
+}
+
+/******************************************************************************/
+static fsal_status_t kvsfs_unlink_reg(struct fsal_obj_handle *dir_hdl,
+				      struct fsal_obj_handle *obj_hdl,
+				      const char *name);
+
+/* FIXME: MDCACHE does not expose find_keyed anymore.
+ * In order to support delete-on-close for RENAME op, we need to figure out
+ * another way to get a cached file handle for the file that
+ * needs to be removed prior rename.
+ */
+#if 0
+/* Finds a file object cached in the inode cache.
+ * The inode cache (MDCACHE) must keep an in-memory file handle structure
+ * if the corresponding file is open.
+ * One of the use cases is a rename() call where a client
+ * is trying to overwrite an existing regular file with another regular file.
+ * The kvsfs_rename needs the information ('share' field from the FH) about
+ * existing open states in order to determine if the file needs to be removed
+ * or not.
+ * NOTE: This function returns only the cached FH but it does not return
+ * an uncached FH (created with kvsfs_lookup).
+ */
+fsal_status_t kvsfs_find_in_mdcache(struct fsal_obj_handle *obj,
+				    struct fsal_obj_handle **obj_cached)
+{
+	struct gsh_buffdesc fh_desc;
+	mdcache_entry_t *mdc_obj_hdl;
+	mdcache_key_t key;
+	fsal_status_t result;
+
+	/* Get a key to be used for searching in the MDCACHE. */
+	obj->obj_ops->handle_to_key(obj, &fh_desc);
+
+	(void) cih_hash_key(&key, op_ctx->fsal_export->fsal, &fh_desc,
+			    CIH_HASH_KEY_PROTOTYPE);
+
+	/* Try to find it in the cache. */
+	result = mdcache_find_keyed(&key, &mdc_obj_hdl);
+	if (FSAL_IS_ERROR(result)) {
+		goto out;
+	}
+
+	/* Get the KVSFS file handle */
+	*obj_cached = mdc_obj_hdl->sub_handle;
+
+out:
+	return result;
+}
+#else
+fsal_status_t kvsfs_find_in_mdcache(struct fsal_obj_handle *obj,
+				    struct fsal_obj_handle **obj_cached)
+{
+	(void) obj;
+	(void) obj_cached;
+	return fsalstat(posix2fsal_error(ENOENT), ENOENT);
+}
+#endif
+
+/* FSAL.rename */
+/** Rename (re-link) an object in a filesystem.
+ *  @param[in] obj_hdl An existing object in the FS to be renamed.
+ *  @param[in] olddir_hdl A parent dir where the object is linked under the
+ *  name `old_name`.
+ *  @param[in] old_name The current name of the object.
+ *  @param[in] newdir_hdl A dir where the object will be linked under the name
+ *  `new_name`.
+ *  @param[in] new_name A name of the object.
+ *  @return @see cfs_rename error codes.
+ */
+static fsal_status_t kvsfs_rename(struct fsal_obj_handle *obj_hdl,
+				  struct fsal_obj_handle *olddir_hdl,
+				  const char *old_name,
+				  struct fsal_obj_handle *newdir_hdl,
+				  const char *new_name)
+{
+	struct kvsfs_fsal_obj_handle *olddir;
+	struct kvsfs_fsal_obj_handle *newdir;
+	struct kvsfs_fsal_obj_handle *obj;
+	struct kvsfs_fsal_obj_handle *newobj;
+	struct fsal_obj_handle *kvsfs_obj_hdl = NULL;
+	struct fsal_obj_handle *newobj_hdl = NULL;
+	struct cfs_rename_flags flags = CFS_RENAME_FLAGS_INIT;
+	fsal_status_t result;
+	int rc = 0;
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+
+	obj = container_of(obj_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+	olddir = container_of(olddir_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+	newdir = container_of(newdir_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+
+#if 1
+	/* TODO:PERF: Consider replacing with assert */
+	if (obj->cfs_fs != olddir->cfs_fs) {
+		LogFatal(COMPONENT_FSAL,
+			 "obj fs_ctx does not match olddir fs_ctx "
+			 "'%p' != '%p'", obj_hdl, olddir_hdl);
+		rc = -EXDEV;
+		goto out;
+	}
+	if (obj->cfs_fs != newdir->cfs_fs) {
+		LogFatal(COMPONENT_FSAL,
+			 "obj fs_ctx does not match newdir fs_ctx "
+			 "'%p' != '%p'", obj_hdl, newdir_hdl);
+		rc = -EXDEV;
+		goto out;
+	}
+#endif
+
+	result = newdir_hdl->obj_ops->lookup(newdir_hdl, new_name, &kvsfs_obj_hdl, NULL);
+	if (result.major == ERR_FSAL_NOENT) {
+		/* Destination object does not exist -> go on and rename. */
+		newobj_hdl = NULL;
+		goto rename;
+	}
+	if (FSAL_IS_ERROR(result)) {
+		LogFatal(COMPONENT_FSAL,
+			 "Failed to lookup destination object: %p/%s",
+			 newdir_hdl, new_name);
+		goto out;
+	}
+
+	/* It is a file handle which will be removed from the file system.
+	 * By default use the FH found by kvsfs_lookup() call.
+	 * */
+	newobj_hdl = kvsfs_obj_hdl;
+
+	if (fsal_obj_handle_is(newobj_hdl, REGULAR_FILE)) {
+		/* Use an FH from the mdcache if it exists in the cache */
+		(void) kvsfs_find_in_mdcache(kvsfs_obj_hdl, &newobj_hdl);
+	}
+
+	newobj = container_of(newobj_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+	flags.is_dst_open = kvsfs_fh_is_open(newobj);
+
+rename:
+	rc = cfs_rename(obj->cfs_fs, &cred,
+			kvsfs_fh_to_ino(olddir->handle), (char *) old_name,
+			kvsfs_fh_to_ino(obj->handle),
+			kvsfs_fh_to_ino(newdir->handle), (char *) new_name,
+			newobj_hdl ? kvsfs_fh_to_ino(newobj->handle) : NULL,
+			&flags);
+
+	result = fsalstat(posix2fsal_error(-rc), -rc);
+
+out:
+	if (kvsfs_obj_hdl) {
+		kvsfs_obj_hdl->obj_ops->release(kvsfs_obj_hdl);
+	}
+	return result;
+
+}
+
+static int kvsfs_xattr_to_acl_entries(void *buf, size_t buflen,
+				      uint32_t *naces_out,
+				      fsal_ace_t **aces_out)
+{
+	int rc = 0;
+	void *offset;
+	fsal_ace_t *aces = NULL;
+	uint32_t naces;
+
+	dassert(buf != NULL);
+	dassert(aces_out != NULL);
+	dassert(naces_out != NULL);
+	dassert(buflen > sizeof(naces))
+
+	if (buflen > CFS_XATTR_SIZE_MAX) {
+		rc = -ERANGE;
+		goto out;
+	}
+
+	offset = buf;
+	/* The first 4 bytes are number of acl entries in the acl. */
+	memcpy(&naces, offset, sizeof(naces));
+	if (naces == 0) {
+		T_TRACE("%s", "No ACEs found!");
+		goto out;
+	}
+
+	offset = offset + sizeof(naces);
+	if ((offset - buf) + naces * sizeof(*aces) > buflen) {
+		rc = -EINVAL;
+		LogCrit(COMPONENT_FSAL,
+			"Incorrect buffer len!! buflen=%zu, naces=%"PRIu32"",
+			buflen, naces);
+		goto out;
+	}
+	aces = (fsal_ace_t *)nfs4_ace_alloc(naces);
+	memcpy(aces, offset, naces * sizeof(*aces));
+
+out:
+	*aces_out = aces;
+	*naces_out = naces;
+	T_EXIT("buf=%p, buflen=%zu, naces_out=%"PRIu32", *aces_out=%p, rc=%d",
+		buf, buflen, *naces_out, *aces_out, rc);
+	return rc;
+}
+
+static fsal_status_t kvsfs_getacl(struct kvsfs_fsal_obj_handle *obj,
+				  cfs_cred_t *cred,
+				  fsal_acl_t **acl_out)
+{
+	char *buf = NULL;
+	int rc;
+	uint32_t naces;
+	size_t buflen = CFS_XATTR_SIZE_MAX;
+	fsal_acl_data_t acl_data;
+	fsal_acl_t *acl = NULL;
+	fsal_acl_status_t acl_status;
+	fsal_status_t result = {ERR_FSAL_NO_ERROR, 0};
+
+	dassert(obj != NULL);
+	dassert(cred != NULL);
+
+	T_ENTER("Enter, obj=%p", obj);
+	buf = gsh_malloc(buflen);
+
+	rc = cfs_getxattr(obj->cfs_fs, cred, kvsfs_fh_to_ino(obj->handle),
+			    ACL_XATTR_NAME, buf, &buflen);
+	if (rc < 0) {
+		T_TRACE("cfs_fs=%p, ino=%p, buf=%p, buflen = %zu, rc=%d",
+			 obj->cfs_fs, kvsfs_fh_to_ino(obj->handle), buf, buflen,
+			 rc);
+		result = fsalstat(posix2fsal_error(-rc), -rc);
+		goto out;
+	}
+
+	dassert(buflen <= CFS_XATTR_SIZE_MAX);
+
+	/* Deserialize the buffer into acl_data. */
+	rc = kvsfs_xattr_to_acl_entries(buf, buflen, &acl_data.naces,
+					&acl_data.aces);
+	if (rc < 0) {
+		LogCrit(COMPONENT_FSAL, "XATTR buf to aces failed, rc=%d "
+		        "obj=%p", obj, rc);
+		result = fsalstat(posix2fsal_error(-rc), -rc);
+		goto out;
+	}
+
+	/* Add a entry to acl cache and get the handle to the actual acl. */
+	acl = nfs4_acl_new_entry(&acl_data, &acl_status);
+	if (!acl) {
+		LogCrit(COMPONENT_FSAL, "Unable to add to acl cache, "
+			"naces=%" PRIu32 ", aces=%p"", acl_status=%d obj=%p",
+			acl_data.naces, acl_data.aces, acl_status, obj);
+		result = fsalstat(ERR_FSAL_FAULT, acl_status);
+		goto out;
+	}
+	fsal_print_acl(COMPONENT_FSAL, NIV_DEBUG, acl);
+	*acl_out = acl;
+
+out:
+	gsh_free(buf);
+	T_EXIT("fs_ctx=%p, ino=%p, acl_out=%p, rc=%d", obj->cfs_fs,
+	        kvsfs_fh_to_ino(obj->handle), *acl_out, rc);
+	return result;
+}
+
+/******************************************************************************/
+/* FSAL.getattr */
+static fsal_status_t kvsfs_getattrs(struct fsal_obj_handle *obj_hdl,
+				    struct attrlist *attrs_out)
+{
+	struct kvsfs_fsal_obj_handle *myself;
+	struct stat stat;
+	int retval = 0;
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+	fsal_status_t result;
+
+	T_ENTER(">>> (%p)", obj_hdl);
+
+	if (attrs_out == NULL) {
+		retval = 0;
+		goto out;
+	}
+
+	myself =
+		container_of(obj_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+
+	retval = cfs_getattr(myself->cfs_fs, &cred,
+			     kvsfs_fh_to_ino(myself->handle), &stat);
+
+	result = fsalstat(posix2fsal_error(-retval), retval);
+	if (FSAL_IS_ERROR(result)) {
+		goto out;
+	}
+
+	posix2fsal_attributes_all(&stat, attrs_out);
+	if (kvsfs_is_acl_enabled()) {
+		fsal_acl_t *acl = NULL;
+		result = kvsfs_getacl(myself, &cred, &acl);
+		if (FSAL_IS_ERROR(result)) {
+			T_TRACE("kvsfs_getacl failed, ino=%p",
+				  kvsfs_fh_to_ino(myself->handle));
+			if (result.major == ENOENT) {
+				result = fsalstat(ERR_FSAL_NO_ERROR, 0);
+				T_TRACE("No aces or acl, ino=%p",
+					 kvsfs_fh_to_ino(myself->handle));
+				attrs_out->acl = NULL;
+				FSAL_SET_MASK(attrs_out->valid_mask, ATTR_ACL);
+			}
+			goto out;
+		}
+		attrs_out->acl = acl;
+		FSAL_SET_MASK(attrs_out->valid_mask, ATTR_ACL);
+	}
+
+out:
+	T_EXIT0(result.major);
+	return result;
+}
+
+/******************************************************************************/
+/* FSAL.getattr */
+
+/* a jury-rigged convertor from NFS attrs into POSIX stats */
+static fsal_status_t kvsfs_setattr_attrlist2stat(struct attrlist *attrs,
+						 struct stat *stats_out,
+						 int *flags_out)
+{
+	int retval = 0;
+	fsal_errors_t fsal_error = ERR_FSAL_NO_ERROR;
+	struct stat stats = { 0};
+	int flags = 0;
+
+	/* apply umask, if mode attribute is to be changed */
+	if (FSAL_TEST_MASK(attrs->valid_mask, ATTR_MODE)) {
+		attrs->mode &= ~op_ctx->fsal_export->exp_ops.
+				fs_umask(op_ctx->fsal_export);
+	}
+
+	if (FSAL_TEST_MASK(attrs->valid_mask, ATTR_SIZE)) {
+		flags |= STAT_SIZE_SET;
+		stats.st_size = attrs->filesize;
+	}
+	if (FSAL_TEST_MASK(attrs->valid_mask, ATTR_MODE)) {
+		flags |= STAT_MODE_SET;
+		stats.st_mode = fsal2unix_mode(attrs->mode);
+	}
+	if (FSAL_TEST_MASK(attrs->valid_mask, ATTR_OWNER)) {
+		flags |= STAT_UID_SET;
+		stats.st_uid = attrs->owner;
+	}
+	if (FSAL_TEST_MASK(attrs->valid_mask, ATTR_GROUP)) {
+		flags |= STAT_GID_SET;
+		stats.st_gid = attrs->group;
+	}
+	if (FSAL_TEST_MASK(attrs->valid_mask, ATTR_ATIME)) {
+		flags |= STAT_ATIME_SET;
+		stats.st_atime = attrs->atime.tv_sec;
+	}
+	if (FSAL_TEST_MASK(attrs->valid_mask, ATTR_ATIME_SERVER)) {
+		flags |= STAT_ATIME_SET;
+		struct timespec timestamp;
+
+		retval = clock_gettime(CLOCK_REALTIME, &timestamp);
+		if (retval != 0)
+			goto out;
+		stats.st_atim = timestamp;
+	}
+	if (FSAL_TEST_MASK(attrs->valid_mask, ATTR_MTIME)) {
+		flags |= STAT_MTIME_SET;
+		stats.st_mtime = attrs->mtime.tv_sec;
+	}
+	if (FSAL_TEST_MASK(attrs->valid_mask, ATTR_MTIME_SERVER)) {
+		flags |= STAT_MTIME_SET;
+		struct timespec timestamp;
+
+		retval = clock_gettime(CLOCK_REALTIME, &timestamp);
+		if (retval != 0)
+			goto out;
+		stats.st_mtim = timestamp;
+	}
+
+out:
+	if (retval == 0) {
+		*flags_out = flags;
+		*stats_out = stats;
+		return fsalstat(ERR_FSAL_NO_ERROR, 0);
+	}
+
+	/* Exit with an error */
+	fsal_error = posix2fsal_error(-retval);
+	return fsalstat(fsal_error, -retval);
+}
+
+/* INTERNAL */
+static fsal_status_t kvsfs_ftruncate(struct fsal_obj_handle *obj,
+				     struct state_t *state, bool bypass,
+				     struct stat *new_stat, int new_stat_flags);
+
+/* FSAL.setattrs2 */
+fsal_status_t kvsfs_setattrs(struct fsal_obj_handle *obj_hdl,
+			     bool bypass,
+			     struct state_t *state,
+			     struct attrlist *attrs)
+{
+	fsal_status_t result;
+	int rc;
+	struct kvsfs_fsal_obj_handle *obj;
+	struct stat stats = { 0 };
+	int flags = 0;
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+
+	T_ENTER(">>> (obj=%p, bypass=%d, state=%p, attrs=%p)", obj_hdl,
+		bypass, state, attrs);
+
+	obj = container_of(obj_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+
+	result = kvsfs_setattr_attrlist2stat(attrs, &stats, &flags);
+	if (FSAL_IS_ERROR(result)) {
+		goto out;
+	}
+
+	if (kvsfs_is_acl_enabled()) {
+		fsal_acl_data_t acl_data;
+		if (FSAL_TEST_MASK(attrs->valid_mask, ATTR_MODE) &&
+		    !FSAL_TEST_MASK(attrs->valid_mask, ATTR_ACL)) {
+		/*
+		@TODO: Set  ACL from mode attributes.
+			-Get ACL using getattrs and set the ACL from
+			 mode.  Sec RFC 7530 sec 6.4.1.1
+		*/
+		}
+		/*
+		If ATTR_ACL is set, mode needs to be set always. See RFC 7530
+		se 6.4.1.2 and 6.4.1.3.
+		*/
+		else {
+			result = fsal_acl_to_mode(attrs);
+		}
+
+		if (FSAL_IS_ERROR(result)) {
+			T_TRACE("Unable to set mode from acl, obj=%p", obj_hdl);
+			goto out;
+		}
+
+		if (FSAL_TEST_MASK(attrs->valid_mask, ATTR_ACL)) {
+			if ((obj_hdl->type != REGULAR_FILE) &&
+			    (obj_hdl->type != DIRECTORY)) {
+				T_TRACE("Setting ACL on non-regular file not"
+					"allowed, %d", obj_hdl->type);
+				result = fsalstat(ERR_FSAL_INVAL, EINVAL);
+				goto out;
+		}
+			else {
+				result = kvsfs_setacl(obj, &cred, attrs->acl);
+				if (FSAL_IS_ERROR(result)) {
+					T_TRACE( "%s", "Set Acl failed");
+					goto out;
+				}
+			}
+		}
+
+	} /* if(kvsfs_is_acl_enabled()) */
+
+	if (FSAL_TEST_MASK(attrs->valid_mask, ATTR_SIZE)) {
+		if (obj_hdl->type != REGULAR_FILE) {
+			LogFullDebug(COMPONENT_FSAL,
+				"Setting size on non-regular file");
+			result = fsalstat(ERR_FSAL_INVAL, EINVAL);
+			goto out;
+		}
+
+		/* Truncate is a special IO-related operation */
+		result = kvsfs_ftruncate(obj_hdl, state, bypass, &stats, flags);
+	} else {
+		/* If the size does not need to be change, then
+		 * we can simply update the stats associated with the inode.
+		 */
+		rc = cfs_setattr(obj->cfs_fs, &cred,
+				 kvsfs_fh_to_ino(obj->handle),
+				 &stats, flags);
+		result = fsalstat(posix2fsal_error(-rc), -rc);
+	}
+
+out:
+	T_EXIT0(result.major);
+	return result;
+}
+
+/******************************************************************************/
+/* INTERNAL */
+static fsal_status_t kvsfs_unlink_reg(struct fsal_obj_handle *dir_hdl,
+				      struct fsal_obj_handle *obj_hdl,
+				      const char *name)
+{
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+	struct kvsfs_fsal_obj_handle *parent;
+	struct kvsfs_fsal_obj_handle *obj;
+	int rc;
+
+	parent = container_of(dir_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+	obj = container_of(obj_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+
+	rc = cfs_detach(parent->cfs_fs, &cred, kvsfs_fh_to_ino(parent->handle),
+			  kvsfs_fh_to_ino(obj->handle), name);
+	if (rc != 0) {
+		goto out;
+	}
+
+	/* FIXME: We might try to use rdlock here instead of wrlock because
+	 * we just need to avoid writing in obj->share. But we don't have have
+	 * atomic operations in CORTXFS yet, so that let's just serialize access
+	 * to destroy_file by enforcing wrlock. */
+	PTHREAD_RWLOCK_wrlock(&obj->obj_handle.obj_lock);
+	if (kvsfs_fh_is_open(obj)) {
+		/* Postpone removal until close */
+		rc = 0;
+	} else {
+		/* No share states detected  -> Delete file object */
+		rc = cfs_destroy_orphaned_file(parent->cfs_fs,
+					       kvsfs_fh_to_ino(obj->handle));
+	}
+	PTHREAD_RWLOCK_unlock(&obj->obj_handle.obj_lock);
+
+out:
+	if (rc != 0 ) {
+		LogCrit(COMPONENT_FSAL, "Failed to unlink reg file"
+			" %llu/%llu '%s'",
+			(unsigned long long) *kvsfs_fh_to_ino(parent->handle),
+			(unsigned long long) *kvsfs_fh_to_ino(obj->handle),
+			name);
+	}
+	return fsalstat(posix2fsal_error(-rc), -rc);
+}
+
+/* INTERNAL */
+static fsal_status_t kvsfs_rmsymlink(struct fsal_obj_handle *dir_hdl,
+				     struct fsal_obj_handle *obj_hdl,
+				     const char *name)
+{
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+	struct kvsfs_fsal_obj_handle *parent;
+	struct kvsfs_fsal_obj_handle *obj;
+	int rc;
+
+	parent = container_of(dir_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+	obj = container_of(obj_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+
+	rc = cfs_unlink(parent->cfs_fs, &cred,
+			  kvsfs_fh_to_ino(parent->handle),
+			  kvsfs_fh_to_ino(obj->handle),
+			  (char *) name);
+	if (rc != 0) {
+		LogCrit(COMPONENT_FSAL, "Failed to rmdir name=%s, rc=%d",
+			name, rc);
+		goto out;
+	}
+
+out:
+	return fsalstat(posix2fsal_error(-rc), -rc);
+}
+
+/* INTERNAL */
+static fsal_status_t kvsfs_rmdir(struct fsal_obj_handle *dir_hdl,
+				 struct fsal_obj_handle *obj_hdl,
+				 const char *name)
+{
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+	struct kvsfs_fsal_obj_handle *parent;
+	int rc;
+
+	parent = container_of(dir_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+
+	/* TODO:PERF:
+	 * Look up has already been done by fsal_remove(),
+	 * so that we can freely pass `obj_hdl` into rmdir()
+	 * in order to avoid the extra lookup() call inside
+	 * rmdir().
+	 */
+
+	rc = cfs_rmdir(parent->cfs_fs, &cred,
+		       kvsfs_fh_to_ino(parent->handle),
+		       (char *) name);
+	if (rc != 0) {
+		LogCrit(COMPONENT_FSAL, "Failed to rmdir name=%s, rc=%d",
+			name, rc);
+		goto out;
+	}
+
+out:
+	return fsalstat(posix2fsal_error(-rc), -rc);
+}
+
+/* FSAL.unlink - Unlink a file or a directory. */
+static fsal_status_t kvsfs_remove(struct fsal_obj_handle *dir_hdl,
+				  struct fsal_obj_handle *obj_hdl,
+				  const char *name)
+{
+	struct kvsfs_fsal_obj_handle *parent;
+	fsal_status_t result;
+
+	if (fsal_obj_handle_is(obj_hdl, DIRECTORY)) {
+		result = kvsfs_rmdir(dir_hdl, obj_hdl, name);
+	} else if (fsal_obj_handle_is(obj_hdl, REGULAR_FILE)) {
+		result = kvsfs_unlink_reg(dir_hdl, obj_hdl, name);
+	} else if (fsal_obj_handle_is(obj_hdl, SYMBOLIC_LINK)) {
+		result = kvsfs_rmsymlink(dir_hdl, obj_hdl, name);
+	}
+
+	return result;
+}
+
+/******************************************************************************/
+/* FSAL.handle_to_wire */
+
+/* Converts in-memory object into opaque byte array.
+ * The byte array is used by the clients as an id of files or directories
+ * (or other file objects).
+ */
+static fsal_status_t kvsfs_handle_digest(const struct fsal_obj_handle *obj_hdl,
+					fsal_digesttype_t output_type,
+					struct gsh_buffdesc *fh_desc)
+{
+	const struct kvsfs_fsal_obj_handle *myself;
+	const size_t fh_size = cfs_fh_serialized_size();
+
+	assert(fh_desc);
+	assert(obj_hdl);
+
+	if (output_type != FSAL_DIGEST_NFSV4) {
+		LogMajor(COMPONENT_FSAL,
+			 "Only NFSv4 File handles are supported."
+			 "Unsupported FH type: %d", output_type);
+		return fsalstat(ERR_FSAL_SERVERFAULT, 0);
+	}
+
+	myself = container_of(obj_hdl, const struct kvsfs_fsal_obj_handle,
+			 obj_handle);
+
+	if (fh_size > fh_desc->len) {
+		LogMajor(COMPONENT_FSAL,
+			 "Space too small for handle (need %d, have %d).",
+			 (int) fh_size, (int) fh_desc->len);
+		return fsalstat(ERR_FSAL_TOOSMALL, ENOBUFS);
+	}
+
+	fh_desc->len = cfs_fh_ser_with_fsid(myself->handle, obj_hdl->fsid.major,
+					    fh_desc->addr,
+					    fh_desc->len);
+
+	return fsalstat(ERR_FSAL_NO_ERROR, 0);
+}
+
+/******************************************************************************/
+/* FSAL_EXPORT.wite_to_host */
+
+/* extract a file handle from a buffer.
+ * do verification checks and flag any and all suspicious bits.
+ * Return an updated fh_desc into whatever was passed.  The most
+ * common behavior, done here is to just reset the length.  There
+ * is the option to also adjust the start pointer.
+ */
+fsal_status_t kvsfs_extract_handle(struct fsal_export *exp_hdl,
+					 fsal_digesttype_t in_type,
+					 struct gsh_buffdesc *fh_desc,
+					 int flags)
+{
+	const size_t fh_size = cfs_fh_serialized_size();
+
+	assert(fh_desc);
+
+	if (in_type != FSAL_DIGEST_NFSV4) {
+		LogMajor(COMPONENT_FSAL,
+			 "Only NFSv4 File handles are supported."
+			 "Unsupported FH type: %d", in_type);
+		return fsalstat(ERR_FSAL_SERVERFAULT, 0);
+	}
+
+
+	if (fh_size < fh_desc->len) {
+		LogMajor(COMPONENT_FSAL,
+			 "Size mismatch for handle.  should be %d, got %d",
+			 (int)  fh_size,
+			 (int) fh_desc->len);
+		return fsalstat(ERR_FSAL_SERVERFAULT, 0);
+	}
+
+	fh_desc->len = fh_size;	/* pass back the actual size */
+	return fsalstat(ERR_FSAL_NO_ERROR, 0);
+}
+
+/******************************************************************************/
+/* FSAL.release - Release a File Handle */
+static void release(struct fsal_obj_handle *obj_hdl)
+{
+	struct kvsfs_fsal_obj_handle *obj;
+
+	obj = container_of(obj_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+
+	fsal_obj_handle_fini(obj_hdl);
+
+	gsh_free(obj);
+}
+
+/******************************************************************************/
+/* FSAL.handle_to_key */
+
+/*
+ * return a handle descriptor into the handle in this object handle
+ * @TODO reminder.  make sure things like hash keys don't point here
+ * after the handle is released.
+ */
+
+static void kvsfs_handle_to_key(struct fsal_obj_handle *obj_hdl,
+				struct gsh_buffdesc *fh_desc)
+{
+	struct kvsfs_fsal_obj_handle *myself;
+
+	myself = container_of(obj_hdl, struct kvsfs_fsal_obj_handle,
+			      obj_handle);
+	cfs_fh_key(myself->handle, &fh_desc->addr, &fh_desc->len);
+}
+
+/******************************************************************************/
+/* FSAL_EXPORT.create_handle */
+
+/* Create handle for export */
+fsal_status_t kvsfs_create_handle(struct fsal_export *exp_hdl,
+				  struct gsh_buffdesc *hdl_desc,
+				  struct fsal_obj_handle **handle,
+				  struct attrlist *attrs_out)
+{
+	int rc = 0;
+	struct cfs_fh *fh = NULL;
+	struct kvsfs_fsal_export *myexport;
+	/* FIXME: It is unclear yet if this function is a subject to access
+	 * checks */
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+
+	assert(exp_hdl);
+	assert(hdl_desc);
+	assert(hdl_desc->addr);
+	assert(handle);
+
+	myexport = container_of(op_ctx->fsal_export,
+				struct kvsfs_fsal_export, export);
+
+	rc = cfs_fh_deserialize(myexport->cfs_fs, &cred,
+				hdl_desc->addr,
+				hdl_desc->len, &fh);
+	if (rc < 0) {
+		goto out;
+	}
+
+	if (attrs_out != NULL) {
+		posix2fsal_attributes_all(cfs_fh_stat(fh), attrs_out);
+	}
+
+	fsal_obj_handle_from_cfs_fh(exp_hdl, &fh, handle);
+
+out:
+	if (fh) {
+		cfs_fh_destroy(fh);
+	}
+
+	return fsalstat(posix2fsal_error(-rc), -rc);
+}
+
+
+/******************************************************************************/
+/** The function is trying to apply the new openflags
+ * and returns the corresponding error if a share conflict
+ * has been detected.
+ */
+static fsal_status_t kvsfs_share_try_new_state(struct kvsfs_fsal_obj_handle *obj,
+					       fsal_openflags_t old_openflags,
+					       fsal_openflags_t new_openflags)
+{
+	fsal_status_t status;
+
+	PTHREAD_RWLOCK_wrlock(&obj->obj_handle.obj_lock);
+
+	status = check_share_conflict(&obj->share, new_openflags, false);
+	if (FSAL_IS_ERROR(status)) {
+		goto out;
+	}
+
+	update_share_counters(&obj->share, old_openflags, new_openflags);
+
+out:
+	PTHREAD_RWLOCK_unlock(&obj->obj_handle.obj_lock);
+	return status;
+}
+
+/* Unconditionally applies the new share reservations state. */
+static void kvsfs_share_set_new_state(struct kvsfs_fsal_obj_handle *obj,
+				      fsal_openflags_t old_openflags,
+				      fsal_openflags_t new_openflags)
+{
+	PTHREAD_RWLOCK_wrlock(&obj->obj_handle.obj_lock);
+
+	update_share_counters(&obj->share, old_openflags, new_openflags);
+
+	PTHREAD_RWLOCK_unlock(&obj->obj_handle.obj_lock);
+}
+
+/******************************************************************************/
+/* A default invalid value for an inode number. */
+#define CFS_INVALID_INO_FOR_FD 0
+static inline
+bool kvsfs_file_state_invariant_closed(const struct kvsfs_file_state *state)
+{
+	return (state->openflags == FSAL_O_CLOSED) &&
+		(state->cfs_fd.ino == CFS_INVALID_INO_FOR_FD);
+}
+
+static inline
+bool kvsfs_file_state_invariant_open(const struct kvsfs_file_state *state)
+{
+	return (state->openflags != FSAL_O_CLOSED) &&
+		(state->cfs_fd.ino != CFS_INVALID_INO_FOR_FD);
+}
+
+/******************************************************************************/
+/* A wrapper for an OPEN-like call at the cortxfs layer which stores
+ * a file state into the KVS.
+ */
+static fsal_status_t cfs_file_open(struct kvsfs_file_state *state,
+				   fsal_openflags_t openflags,
+				   struct kvsfs_fsal_obj_handle *obj)
+{
+	(void) state;
+	(void) openflags;
+	(void) obj;
+	return fsalstat(ERR_FSAL_NO_ERROR, 0);
+}
+
+/* A wrapper for a CLOSE-like call at the cortxfs layer which lets the KVS
+ * know that we don't need to keep the file open anymore.
+ * @see cfs_file_open.
+ */
+static fsal_status_t cfs_file_close(struct kvsfs_file_state *state,
+				    struct kvsfs_fsal_obj_handle *obj)
+{
+	(void) state;
+	(void) obj;
+	return fsalstat(ERR_FSAL_NO_ERROR, 0);
+}
+
+/* Opens and re-opens a file handle and creates (or re-uses) a file state
+ * checking share reservations and propogating open call down into cortxfs.
+ */
+static fsal_status_t kvsfs_file_state_open(struct kvsfs_file_state *state,
+					   const fsal_openflags_t openflags,
+					   struct kvsfs_fsal_obj_handle *obj,
+					   bool is_reopen)
+{
+	fsal_status_t status;
+
+	if (!is_reopen) {
+		/* we cannot open the same state twice unless it is a reopen*/
+		assert(kvsfs_file_state_invariant_closed(state));
+	}
+
+	status = kvsfs_share_try_new_state(obj, state->openflags, openflags);
+	if (FSAL_IS_ERROR(status)) {
+		goto out;
+	}
+
+	status = cfs_file_open(state, openflags, obj);
+	if (FSAL_IS_ERROR(status)) {
+		goto undo_share;
+	}
+
+	state->openflags = openflags;
+	state->cfs_fd.ino = *kvsfs_fh_to_ino(obj->handle);
+
+	assert(kvsfs_file_state_invariant_open(state));
+	status = fsalstat(ERR_FSAL_NO_ERROR, 0);
+
+undo_share:
+	if (FSAL_IS_ERROR(status)) {
+		kvsfs_share_set_new_state(obj, openflags, state->openflags);
+	}
+
+out:
+	/* On exit it has to either remain closed (on error) or
+	 * be in an open state (success).
+	 */
+	if (FSAL_IS_ERROR(status) && !is_reopen) {
+		assert(kvsfs_file_state_invariant_closed(state));
+	} else {
+		assert(kvsfs_file_state_invariant_open(state));
+	}
+
+	return status;
+}
+
+/******************************************************************************/
+/* Closes a file state associate with a file handle. */
+static fsal_status_t kvsfs_file_state_close(struct kvsfs_file_state *state,
+					    struct kvsfs_fsal_obj_handle *obj)
+{
+	fsal_status_t status;
+
+	assert(state != NULL);
+	assert(kvsfs_file_state_invariant_open(state));
+
+	status = cfs_file_close(state, obj);
+	if (FSAL_IS_ERROR(status)) {
+		goto out;
+	}
+
+	kvsfs_share_set_new_state(obj, state->openflags, FSAL_O_CLOSED);
+
+	state->openflags = FSAL_O_CLOSED;
+	state->cfs_fd.ino = CFS_INVALID_INO_FOR_FD;
+
+out:
+	/* We cannot guarantee that the file is always closed,
+	 * but at least we can assume that the succesfull result always
+	 * leads to the closed state
+	 */
+	if (!FSAL_IS_ERROR(status)) {
+		assert(kvsfs_file_state_invariant_closed(state));
+	}
+
+	return status;
+}
+
+/******************************************************************************/
+/** Find a readable/writeable FD using a file state (including locking state)
+ * as a base.
+ * Sometimes an NFS Client may try to use a stateid associated with a state lock
+ * to read/write/setattr(truncate) a file. Such a stateid cannot be used
+ * directly in read/write calls. However, it is possible to use this state
+ * to identify the correponding open state which, in turn, can be used in
+ * IO operations.
+ * NFS Ganesha has similiar function ::fsal_find_fd which does the same
+ * thing but it has 13 arguments and handles all possible scenarious like
+ * NFSv3, share reservation checks, NFSv4 open, NFSv4 locks, NLM locks
+ * and so on. On contrary, kvsfs_find_fd handles only NFSv4 open and locked
+ * states. In future, we may have to add handling of bypass mode
+ * (special stateids, see EOS-1479).
+ * @param fsal_state A file state passed down from NFS Ganesha for IO callback.
+ * @param bypass Bypass share reservations flag.
+ * @param[out] fd Pointer to an FD to be filled.
+ * @return So far always returns OK.
+ */
+static fsal_status_t kvsfs_find_fd(struct state_t *fsal_state,
+				   bool bypass,
+				   fsal_openflags_t openflags,
+				   struct kvsfs_file_state **fd)
+{
+	fsal_status_t result = fsalstat(ERR_FSAL_NO_ERROR, 0);
+	struct kvsfs_state_fd *kvsfs_state;
+
+	T_ENTER(">>> (state=%p, bypass=%d, openflags=%d, fd=%p)",
+		fsal_state, (int) bypass, (int) openflags, fd);
+
+	assert(fd != NULL);
+
+	assert(fsal_state->state_type == STATE_TYPE_LOCK ||
+	       fsal_state->state_type == STATE_TYPE_SHARE ||
+	       fsal_state->state_type == STATE_TYPE_DELEG);
+
+	/* TODO:EOS-1479: We don't suppport special state ids yet. */
+	assert(bypass == false);
+	assert(fsal_state != NULL);
+
+	/* We don't have an open file for locking states,
+	 * therefore let's just reuse the associated open state.
+	 */
+	if (fsal_state->state_type == STATE_TYPE_LOCK) {
+		fsal_state = fsal_state->state_data.lock.openstate;
+		assert(fsal_state != NULL);
+	}
+
+	kvsfs_state = container_of(fsal_state, struct kvsfs_state_fd, state);
+
+	if (open_correct(kvsfs_state->kvsfs_fd.openflags, openflags)) {
+		*fd = &kvsfs_state->kvsfs_fd;
+		goto out;
+	}
+
+	/* if there is no suitable FD for this fsal_state then it is likely
+	 * has been caused by a state type which we cannot handle right now.
+	 * Let's just print some logs and then fail right here.
+	 */
+	LogCrit(COMPONENT_FSAL, "Unsupported state type: %d",
+		(int) fsal_state->state_type);
+	assert(0); /* Unreachable */
+
+out:
+	T_EXIT0(result.major);
+	return result;
+}
+
+/******************************************************************************/
+/* FSAL_EXPORT.alloc_state */
+struct state_t *kvsfs_alloc_state(struct fsal_export *exp_hdl,
+				enum state_type state_type,
+				struct state_t *related_state)
+{
+	struct kvsfs_state_fd *super;
+
+	super = gsh_calloc(1, sizeof(struct kvsfs_state_fd));
+
+	super->kvsfs_fd.openflags = FSAL_O_CLOSED;
+	super->kvsfs_fd.cfs_fd.ino = CFS_INVALID_INO_FOR_FD;
+
+	return init_state(&super->state, exp_hdl, state_type, related_state);
+}
+
+/******************************************************************************/
+/* FSAL_EXPORT.free_state */
+void kvsfs_free_state(struct fsal_export *exp_hdl, struct state_t *state)
+{
+	struct kvsfs_state_fd *super;
+
+	(void) exp_hdl;
+
+	super = container_of(state, struct kvsfs_state_fd, state);
+
+	gsh_free(super);
+}
+
+/******************************************************************************/
+/* FSAL.lease_op2 */
+static fsal_status_t kvsfs_lease_op2(struct fsal_obj_handle *obj_hdl,
+				     struct state_t *state_hdl,
+				     void *owner,
+				     fsal_deleg_t deleg)
+{
+	fsal_status_t result = fsalstat(ERR_FSAL_NO_ERROR, 0);
+	struct kvsfs_state_fd *state;
+	struct kvsfs_fsal_obj_handle *obj;
+
+	T_ENTER(">>> (obj_hdl=%p, state=%p, owner=%p, deleg=%d)",
+		obj_hdl, state_hdl, owner, (int) deleg);
+
+	assert(obj_hdl);
+	assert(state_hdl);
+	assert(state_hdl->state_type == STATE_TYPE_DELEG);
+
+	state = container_of(state_hdl, struct kvsfs_state_fd, state);
+	obj = container_of(obj_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+
+	/* We are not working in clustered environment yet,
+	 * so that let's leave conflicts detection to NFS Ganesha.
+	 */
+
+	switch (deleg) {
+	case FSAL_DELEG_NONE:
+		T_TRACE("%s", "Releasing delegation");
+		assert(kvsfs_file_state_invariant_open(&state->kvsfs_fd));
+		result = kvsfs_file_state_close(&state->kvsfs_fd, obj);
+		break;
+
+	/* For Read and Write delegation we can simply "open" the file for
+	 * RD or WR mode and then in find_fd extract this FD from the
+	 * kvsfs state in the same way as it works with "Share" states,
+	 * thus avoiding the need to open anything inside READ/WRITE calls
+	 * when the client would like to read out or to flush data back
+	 * to the server.
+	 * FIXME: We don't know yet if it is possible to get a reopen-like
+	 * sequence of calls from NFS Ganesha (from the same client), so that
+	 * we assume that it will never happen and passing reopen=false
+	 * for the READ and WRITE open calls.
+	 */
+	case FSAL_DELEG_RD:
+		T_TRACE("%s", "Read delegation");
+		assert(kvsfs_file_state_invariant_closed(&state->kvsfs_fd));
+		result = kvsfs_file_state_open(&state->kvsfs_fd, FSAL_O_READ,
+					       obj, false);
+		break;
+	case FSAL_DELEG_WR:
+		T_TRACE("%s", "Write delegation");
+		assert(kvsfs_file_state_invariant_closed(&state->kvsfs_fd));
+		result = kvsfs_file_state_open(&state->kvsfs_fd, FSAL_O_WRITE,
+					       obj, false);
+		break;
+	}
+
+	T_EXIT0(result.major);
+	return result;
+}
+
+/******************************************************************************/
+/* FSAL.open2 */
+#if 0
+/* Copied from fsal API */
+/**
+ * @brief Open a file descriptor for read or write and possibly create
+ *
+ * This function opens a file for read or write, possibly creating it.
+ * If the caller is passing a state, it must hold the state_lock
+ * exclusive.
+ *
+ * state can be NULL which indicates a stateless open (such as via the
+ * NFS v3 CREATE operation), in which case the FSAL must assure protection
+ * of any resources. If the file is being created, such protection is
+ * simple since no one else will have access to the object yet, however,
+ * in the case of an exclusive create, the common resources may still need
+ * protection.
+ *
+ * If Name is NULL, obj_hdl is the file itself, otherwise obj_hdl is the
+ * parent directory.
+ *
+ * On an exclusive create, the upper layer may know the object handle
+ * already, so it MAY call with name == NULL. In this case, the caller
+ * expects just to check the verifier.
+ *
+ * On a call with an existing object handle for an UNCHECKED create,
+ * we can set the size to 0.
+ *
+ * At least the mode attribute must be set if createmode is not FSAL_NO_CREATE.
+ * Some FSALs may still have to pass a mode on a create call for exclusive,
+ * and even with FSAL_NO_CREATE, and empty set of attributes MUST be passed.
+ *
+ * If an open by name succeeds and did not result in Ganesha creating a file,
+ * the caller will need to do a subsequent permission check to confirm the
+ * open. This is because the permission attributes were not available
+ * beforehand.
+ *
+ * The caller is expected to invoke fsal_release_attrs to release any
+ * resources held by the set attributes. The FSAL layer MAY have added an
+ * inherited ACL.
+ *
+ * The caller will set the request_mask in attrs_out to indicate the attributes
+ * of interest. ATTR_ACL SHOULD NOT be requested and need not be provided. If
+ * not all the requested attributes can be provided, this method MUST return
+ * an error unless the ATTR_RDATTR_ERR bit was set in the request_mask.
+ *
+ * Since this method may instantiate a new fsal_obj_handle, it will be forced
+ * to fetch at least some attributes in order to even know what the object
+ * type is (as well as it's fileid and fsid). For this reason, the operation
+ * as a whole can be expected to fail if the attributes were not able to be
+ * fetched.
+ *
+ * The attributes will not be returned if this is an open by object as
+ * opposed to an open by name.
+ *
+ * @note If the file was created, @a new_obj has been ref'd
+ *
+ * @param[in] obj_hdl               File to open or parent directory
+ * @param[in,out] state             state_t to use for this operation
+ * @param[in] openflags             Mode for open
+ * @param[in] createmode            Mode for create
+ * @param[in] name                  Name for file if being created or opened
+ * @param[in] attrs_in              Attributes to set on created file
+ * @param[in] verifier              Verifier to use for exclusive create
+ * @param[in,out] new_obj           Newly created object
+ * @param[in,out] attrs_out         Optional attributes for newly created object
+ * @param[in,out] caller_perm_check The caller must do a permission check
+ *
+ * @return FSAL status.
+ */
+#endif
+
+static fsal_status_t kvsfs_open2_by_handle(struct fsal_obj_handle *obj_hdl,
+					   struct state_t *state,
+					   fsal_openflags_t openflags,
+					   struct attrlist *attrs_out,
+					   bool *caller_perm_check)
+{
+	struct kvsfs_fsal_obj_handle *obj;
+	int rc = 0;
+	fsal_status_t status = fsalstat(ERR_FSAL_NO_ERROR, 0);
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+	struct kvsfs_file_state *fd;
+	struct stat stat;
+
+	fd = &container_of(state, struct kvsfs_state_fd, state)->kvsfs_fd;
+	obj = container_of(obj_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+
+	status = kvsfs_file_state_open(fd, openflags, obj, false);
+	if (FSAL_IS_ERROR(status)) {
+		goto out;
+	}
+
+	if (attrs_out != NULL) {
+		rc = cfs_getattr(obj->cfs_fs, &cred,
+				 kvsfs_fh_to_ino(obj->handle), &stat);
+		if (rc < 0) {
+			status = fsalstat(posix2fsal_error(-rc), -rc);
+			goto out;
+		}
+
+		posix2fsal_attributes_all(&stat, attrs_out);
+	}
+
+	/* kvsfs_file_state_open does not call test_access and
+	 * cfs_getattrs also does not check it. Therefore, let the caller
+	 * check access.
+	 */
+	if (caller_perm_check) {
+		*caller_perm_check = true;
+	}
+
+out:
+	return status;
+}
+
+static fsal_status_t kvsfs_open2_by_name(struct fsal_obj_handle *parent_obj_hdl,
+					 const char *name,
+					 struct fsal_obj_handle **new_obj_hdl,
+					 struct state_t *state,
+					 fsal_openflags_t openflags,
+					 struct attrlist *attrs_in,
+					 struct attrlist *attrs_out,
+					 bool *caller_perm_check)
+{
+	fsal_status_t result;
+	struct fsal_obj_handle *obj = NULL;
+
+	assert(name);
+
+	result = parent_obj_hdl->obj_ops->lookup(parent_obj_hdl, name, &obj,
+						 NULL);
+	if (FSAL_IS_ERROR(result)) {
+		goto out;
+	}
+
+	assert(obj != NULL);
+
+	result = kvsfs_open2_by_handle(obj, state, openflags,
+				       attrs_out, caller_perm_check);
+	if (FSAL_IS_ERROR(result)) {
+		goto free_obj;
+	}
+
+	/* Give it to the caller */
+	*new_obj_hdl = obj;
+	obj = NULL;
+
+free_obj:
+	if (obj) {
+		obj->obj_ops->release(obj);
+	}
+out:
+	return result;
+}
+
+/** Implementation of OPEN4+UNCHECKED4 case when the file exists. */
+static fsal_status_t kvsfs_open_unchecked(struct fsal_obj_handle *obj_hdl,
+					  struct state_t *state,
+					  fsal_openflags_t openflags,
+					  struct attrlist *attrs_in,
+					  struct attrlist *attrs_out,
+					  bool *caller_perm_check)
+{
+	fsal_status_t result = fsalstat(ERR_FSAL_NO_ERROR, 0);
+	bool close_on_exit = false;
+	struct stat stat = {0};
+	int flags = 0;
+
+	T_ENTER(">>> (obj=%p, state=%p, attrs_in=%p, attrs_out=%p)",
+		obj_hdl, state, attrs_in, attrs_out);
+
+	assert(obj_hdl);
+	assert(attrs_in);
+	assert(state);
+	assert(obj_hdl->type == REGULAR_FILE);
+
+	result = kvsfs_open2_by_handle(obj_hdl, state, openflags, attrs_out,
+				       caller_perm_check);
+	if (FSAL_IS_ERROR(result)) {
+		goto out;
+	}
+
+	close_on_exit = true;
+
+	/* TODO: When all OPEN4 cases are implemented,
+	 * this O_TRUNC processing might be integrated into open_by_handle.
+	 */
+	if ((openflags & FSAL_O_TRUNC) != 0) {
+		flags |= STAT_SIZE_SET;
+		stat.st_size = 0;
+		result = kvsfs_ftruncate(obj_hdl, state, false, &stat, flags);
+		if (FSAL_IS_ERROR(result)) {
+			goto out;
+		}
+		/* We don't need to change attrs_out->filesize here
+		 * because its is unset by Ganesha already.
+		 */
+	}
+
+	close_on_exit = false;
+out:
+	if (close_on_exit) {
+		(void) obj_hdl->obj_ops->close2(obj_hdl, state);
+	}
+	T_EXIT0(result.major);
+	return result;
+}
+
+
+
+/** Implementation of OPEN4+UNCHECKED4 case when the file does not exist. */
+static fsal_status_t
+kvsfs_create_unchecked(struct fsal_obj_handle *parent_obj_hdl, const char *name,
+		       struct state_t *state, struct fsal_obj_handle **pnew_obj,
+		       fsal_openflags_t openflags, struct attrlist *attrs_in,
+		       struct attrlist *attrs_out, bool *caller_perm_check)
+{
+	fsal_status_t result = fsalstat(ERR_FSAL_NO_ERROR, 0);
+	int rc;
+	struct kvsfs_fsal_obj_handle *parent_obj;
+	struct fsal_obj_handle *obj_hdl = NULL;
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+	cfs_ino_t object;
+	struct stat stat_in;
+	struct stat stat_out;
+	int flags;
+
+	T_ENTER(">>> (parent=%p, state=%p, name=%s, attrs_in=%p, attrs_out=%p)",
+		parent_obj_hdl, state, name, attrs_in, attrs_out);
+
+	/* Ganesha sets ATTR_MODE even if the client didn't set it */
+	assert(FSAL_TEST_MASK(attrs_in->valid_mask, ATTR_MODE));
+	assert(name != NULL);
+	assert(state && parent_obj_hdl);
+
+	parent_obj = container_of(parent_obj_hdl,
+				  struct kvsfs_fsal_obj_handle, obj_handle);
+
+	result = kvsfs_setattr_attrlist2stat(attrs_in, &stat_in, &flags);
+	if (FSAL_IS_ERROR(result)) {
+		goto out;
+	}
+
+	rc = cfs_creat_ex(parent_obj->cfs_fs, &cred,
+			  kvsfs_fh_to_ino(parent_obj->handle),
+			  (char *) name,
+			  stat_in.st_mode,
+			  &stat_in, flags,
+			  &object,
+			  &stat_out);
+	if (rc < 0) {
+		result = fsalstat(posix2fsal_error(-rc), -rc);
+		goto out;
+	}
+
+	construct_handle(op_ctx->fsal_export, &object, &stat_out, &obj_hdl);
+
+	result = kvsfs_open2_by_handle(obj_hdl, state, openflags, NULL, NULL);
+	if (FSAL_IS_ERROR(result)) {
+		goto out;
+	}
+
+	if (attrs_out != NULL) {
+		posix2fsal_attributes_all(&stat_out, attrs_out);
+	}
+
+	*pnew_obj = obj_hdl;
+	obj_hdl = NULL;
+
+	/* We have already checked permissions in cfs_create */
+	if (caller_perm_check) {
+		*caller_perm_check = false;
+	}
+
+	T_TRACE("Created: %p", *pnew_obj);
+
+out:
+	if (obj_hdl != NULL) {
+		obj_hdl->obj_ops->release(obj_hdl);
+	}
+	T_EXIT0(result.major);
+	return result;
+}
+
+/** Implementation of OPEN4+EXCLUSIVE4 case when the file does not exist.
+ * At first NFS Ganesha checks if the file exists. If it doesn't then ganesha
+ * calls the fsal open2 callback. If it exists then ganesha checks the verifier
+ * in order to determine if it is a retransmission.
+ */
+static fsal_status_t
+kvsfs_create_exclusive40(struct fsal_obj_handle *parent_obj_hdl, const char *name,
+			 struct state_t *state, struct fsal_obj_handle **pnew_obj,
+			 fsal_openflags_t openflags, struct attrlist *attrs_in,
+			 struct attrlist *attrs_out, bool *caller_perm_check,
+			 fsal_verifier_t verifier)
+{
+	fsal_status_t result = fsalstat(ERR_FSAL_NO_ERROR, 0);
+	int rc;
+	struct kvsfs_fsal_obj_handle *parent_obj;
+	struct fsal_obj_handle *obj_hdl = NULL;
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+	cfs_ino_t object;
+	struct stat stat_in;
+	struct stat stat_out;
+	int flags;
+
+	/* attrs_in is not empty but only fattr.mode is set. */
+	assert(attrs_in);
+	/* but only mode is set by NFS Ganesha */
+	assert(attrs_in->valid_mask == ATTR_MODE);
+
+	assert(name);
+
+	/* Use ATIME and MTIME attrs as verifiers. */
+	set_common_verifier(attrs_in, verifier);
+
+	assert(FSAL_TEST_MASK(attrs_in->valid_mask, ATTR_ATIME));
+	assert(FSAL_TEST_MASK(attrs_in->valid_mask, ATTR_MTIME));
+	assert(FSAL_TEST_MASK(attrs_in->valid_mask, ATTR_MODE));
+
+	/* create operations do not support the truncate flag */
+	assert((openflags & FSAL_O_TRUNC) == 0);
+
+	result = kvsfs_setattr_attrlist2stat(attrs_in, &stat_in, &flags);
+	if (FSAL_IS_ERROR(result)) {
+		/* this function cannot fail if we are setting only
+		 * atime, mtime and mode.
+		 */
+		assert(0);
+		goto out;
+	}
+
+	parent_obj = container_of(parent_obj_hdl,
+				  struct kvsfs_fsal_obj_handle, obj_handle);
+
+	rc = cfs_creat_ex(parent_obj->cfs_fs, &cred,
+			  kvsfs_fh_to_ino(parent_obj->handle),
+			  (char *) name,
+			  stat_in.st_mode,
+			  &stat_in, flags,
+			  &object,
+			  &stat_out);
+	if (rc < 0) {
+		result = fsalstat(posix2fsal_error(-rc), -rc);
+		goto out;
+	}
+
+	construct_handle(op_ctx->fsal_export, &object, &stat_out, &obj_hdl);
+
+	result = kvsfs_open2_by_handle(obj_hdl, state, openflags, NULL, NULL);
+	if (FSAL_IS_ERROR(result)) {
+		goto out;
+	}
+
+	*pnew_obj = obj_hdl;
+	obj_hdl = NULL;
+
+	if (attrs_out != NULL) {
+		posix2fsal_attributes_all(&stat_out, attrs_out);
+	}
+
+	/* We have already checked permissions in cfs_creat_ex */
+	if (caller_perm_check) {
+		*caller_perm_check = false;
+	}
+
+	T_TRACE("Created: %p", *pnew_obj);
+
+out:
+	if (obj_hdl != NULL) {
+		obj_hdl->obj_ops->release(obj_hdl);
+	}
+	T_EXIT0(result.major);
+	return result;
+}
+
+/* Open a file which has been created with O_EXCL but was not opened. */
+static fsal_status_t
+kvsfs_open_exclusive40(struct fsal_obj_handle *obj_hdl,
+		       struct state_t *state,
+		       fsal_openflags_t openflags,
+		       struct attrlist *attrs_in,
+		       struct attrlist *attrs_out,
+		       bool *caller_perm_check)
+{
+	fsal_status_t result;
+
+	T_ENTER(">>> (obj=%p, st=%p, open=%d, pcheck=%p)",
+		obj_hdl, state, openflags, caller_perm_check);
+
+	assert(obj_hdl);
+
+	/* attrs_in is set */
+	assert(attrs_in);
+	/* but only fattr.mode is set by NFS Ganesha. And in an open call
+	 * we should ignore it. */
+	assert(attrs_in->valid_mask == ATTR_MODE);
+
+	/* Truncate is not allowed */
+	assert((openflags & FSAL_O_TRUNC) == 0);
+
+	/* let open_by_handle fill in the attrs and the perm check  flag */
+	result = kvsfs_open2_by_handle(obj_hdl, state, openflags, attrs_out,
+				       caller_perm_check);
+	if (FSAL_IS_ERROR(result)) {
+		goto out;
+	}
+
+out:
+	T_EXIT0(result.major);
+	return result;
+}
+
+static fsal_status_t kvsfs_open2(struct fsal_obj_handle *obj_hdl,
+				 struct state_t *state,
+				 fsal_openflags_t openflags,
+				 enum fsal_create_mode createmode,
+				 const char *name,
+				 struct attrlist *attrs_in,
+				 fsal_verifier_t verifier,
+				 struct fsal_obj_handle **new_obj,
+				 struct attrlist *attrs_out,
+				 bool *caller_perm_check)
+{
+	fsal_status_t result;
+
+	T_ENTER(">>> (obj=%p, st=%p, open=%d, create=%d,"
+		" name=%s, attr_in=%p, verf=%d, new=%p,"
+		" attr_out=%p, pcheck=%p)",
+		obj_hdl, state, openflags, createmode,
+		name, attrs_in, verifier[0], new_obj,
+		attrs_out, caller_perm_check);
+
+	T_TRACE("openflags: read=%d, write=%d, trunc=%d",
+		(openflags & FSAL_O_READ),
+		(openflags & FSAL_O_WRITE),
+		(openflags & FSAL_O_TRUNC));
+
+	assert(obj_hdl);
+
+	if (state == NULL) {
+		LogCrit(COMPONENT_FSAL,
+			"KVSFS does not support NFSv3 clients.");
+		result = fsalstat(ERR_FSAL_NOTSUPP, 0);
+		goto out;
+	}
+
+	if (attrs_in != NULL) {
+		LogAttrlist(COMPONENT_FSAL, NIV_FULL_DEBUG,
+			    "attris_in ", attrs_in, false);
+	}
+
+	if (createmode == FSAL_NO_CREATE) {
+		if (name == NULL) {
+			result = kvsfs_open2_by_handle(obj_hdl, state,
+						       openflags,
+						       attrs_out,
+						       caller_perm_check);
+		} else {
+			result = kvsfs_open2_by_name(obj_hdl, name, new_obj,
+						     state, openflags,
+						     attrs_in, attrs_out,
+						     caller_perm_check);
+		}
+	} else {
+		switch (createmode) {
+		case FSAL_UNCHECKED:
+			if (name != NULL) {
+				T_TRACE("%s", "Create Unchecked4");
+				result = kvsfs_create_unchecked(obj_hdl,
+								name,
+								state,
+								new_obj,
+								openflags,
+								attrs_in,
+								attrs_out,
+								caller_perm_check);
+			} else {
+				T_TRACE("%s", "Open Unchecked4");
+				result = kvsfs_open_unchecked(obj_hdl,
+							      state,
+							      openflags,
+							      attrs_in,
+							      attrs_out,
+							      caller_perm_check);
+			}
+			break;
+		case FSAL_GUARDED:
+			/* NFS Ganesha has already checked object existence.
+			 * According to the RFC 4.0, the behavior in this case
+			 * is the same as with Unchecked4 create.
+			 */
+			/*
+			 * NOTE: Guarded4 is not used by the linux nfs client
+			 * unless it uses NFS4.1 proto (which is not supported
+			 * yet on our side).
+			 * Therefore, this code path can be checked only
+			 * by manually creating RPC requests or by
+			 * using NFS4.1 linux nfs client.
+			 * Moreover, Guarded4 is used by NFS4.1 only if
+			 * the corresponding 4.1 session is persistent
+			 * (see fs/nfs/nfs4proc.c, nfs4_open_prepare).
+			 */
+			T_TRACE("%s", "Create Guarded4");
+			result = kvsfs_create_unchecked(obj_hdl,
+							name,
+							state,
+							new_obj,
+							openflags,
+							attrs_in,
+							attrs_out,
+							caller_perm_check);
+			break;
+		case FSAL_EXCLUSIVE:
+			/* Handles NFS4.0 version of open(O_CREAT | O_EXCL).
+			 * Note: it is different from NFS4.1. O_EXCL.
+			 */
+			if (name == NULL) {
+				/* We end up here if Ganesha detects
+				 * that is was a re-transmit, i.e.
+				 * Ganesha has done lookup() and checked
+				 * the verifier and it matched.
+				 * At this point we should just open
+				 * the file.
+				 */
+				T_TRACE("%s", "Open Exclusive4");
+				result = kvsfs_open_exclusive40(obj_hdl,
+								state,
+								openflags,
+								attrs_in,
+								attrs_out,
+								caller_perm_check);
+			} else {
+				T_TRACE("%s", "Create Exclusive4");
+				/* A normal O_EXCL create operation */
+				result = kvsfs_create_exclusive40(obj_hdl,
+								  name,
+								  state,
+								  new_obj,
+								  openflags,
+								  attrs_in,
+								  attrs_out,
+								  caller_perm_check,
+								  verifier);
+			}
+			break;
+		case FSAL_NO_CREATE:
+			/* Impossible */
+			assert(0);
+			break;
+		case FSAL_EXCLUSIVE_41:
+		case FSAL_EXCLUSIVE_9P:
+			result = fsalstat(ERR_FSAL_NOTSUPP, ENOTSUP);
+			break;
+		}
+	}
+
+out:
+	T_EXIT0(result.major);
+	return result;
+}
+
+/******************************************************************************/
+static fsal_status_t kvsfs_reopen2(struct fsal_obj_handle *obj_hdl,
+				   struct state_t *state_hdl,
+				   fsal_openflags_t openflags)
+{
+	struct kvsfs_fsal_obj_handle *obj;
+	struct kvsfs_file_state *fd;
+	fsal_status_t status;
+
+	assert(obj_hdl);
+	assert(state_hdl);
+
+	T_ENTER(">>> (obj=%p, state=%p, openflags=%d)",
+		obj_hdl, state_hdl, openflags);
+
+	T_TRACE("openflags: read=%d, write=%d, trunc=%d",
+		(openflags & FSAL_O_READ),
+		(openflags & FSAL_O_WRITE),
+		(openflags & FSAL_O_TRUNC));
+
+	obj = container_of(obj_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+	fd = &container_of(state_hdl, struct kvsfs_state_fd, state)->kvsfs_fd;
+
+	status = kvsfs_file_state_open(fd, openflags, obj, true);
+	if (FSAL_IS_ERROR(status)) {
+		goto out;
+	}
+
+out:
+	T_EXIT0(status.major);
+	return status;
+}
+
+/******************************************************************************/
+/* FSAL.status2 */
+static fsal_openflags_t kvsfs_status2(struct fsal_obj_handle *obj_hdl,
+				      struct state_t *state)
+{
+	struct kvsfs_state_fd *state_fd;
+
+	T_ENTER(">>> (obj=%p, state=%p)", obj_hdl, state);
+
+	assert(state != NULL);
+
+	state_fd = container_of(state, struct kvsfs_state_fd, state);
+
+	T_EXIT0(0);
+	return state_fd->kvsfs_fd.openflags;
+}
+
+/******************************************************************************/
+/* FSAL.close2 */
+
+static inline const char *state_type2str(enum state_type state_type)
+{
+	switch(state_type) {
+	case STATE_TYPE_LOCK:
+		return "LOCK";
+	case STATE_TYPE_SHARE:
+		return "SHARE";
+	case STATE_TYPE_DELEG:
+		return "DELEG";
+	case STATE_TYPE_LAYOUT:
+		return "LAYOUT";
+	case STATE_TYPE_NLM_LOCK:
+		return "NLM_LOCK";
+	case STATE_TYPE_NLM_SHARE:
+		return "NLM_SHARE";
+	case STATE_TYPE_9P_FID:
+		return "9P_FID";
+	case STATE_TYPE_NONE:
+		return "NONE";
+	}
+
+	return "<unknown>";
+}
+
+static fsal_status_t kvsfs_delete_on_close(struct fsal_obj_handle *obj_hdl)
+{
+	fsal_status_t result;
+	struct kvsfs_state_fd *state_fd;
+	struct kvsfs_fsal_obj_handle *obj;
+	int rc;
+
+	T_ENTER("%p", obj_hdl);
+
+	PTHREAD_RWLOCK_wrlock(&obj_hdl->obj_lock);
+
+	if (!fsal_obj_handle_is(obj_hdl, REGULAR_FILE)) {
+		LogDebug(COMPONENT_FSAL, "Only a regular file can be closed");
+		rc = 0;
+		goto out;
+	}
+
+	obj = container_of(obj_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+
+	/* Check if there are any active SHARE states */
+	if (kvsfs_fh_is_open(obj)) {
+		T_TRACE("%s", "File is still open.");
+		rc = 0;
+		goto out;
+	}
+
+	/* TODO:PERF: Although this call checks st_nlink against zero,
+	 * we can cache this value in the FH in order to avoid getattr()
+	 * call inside this function.
+	 */
+	rc = cfs_destroy_orphaned_file(obj->cfs_fs,
+				       kvsfs_fh_to_ino(obj->handle));
+	if (rc != 0) {
+		LogCrit(COMPONENT_FSAL,
+			"Failed to destroy file object %llu (%p)",
+			(unsigned long long) *kvsfs_fh_to_ino(obj->handle),
+			obj_hdl);
+		goto out;
+	}
+
+out:
+	PTHREAD_RWLOCK_unlock(&obj_hdl->obj_lock);
+	T_EXIT0(rc);
+	return fsalstat(posix2fsal_error(-rc), -rc);
+}
+
+static fsal_status_t kvsfs_close2(struct fsal_obj_handle *obj_hdl,
+				  struct state_t *state)
+{
+	fsal_status_t result = fsalstat(ERR_FSAL_NO_ERROR, 0);
+	struct kvsfs_state_fd *state_fd;
+	struct kvsfs_fsal_obj_handle *obj;
+
+	assert(state != NULL);
+
+	T_ENTER(">>> (obj=%p, state=%p, type=%s)", obj_hdl, state,
+		state_type2str(state->state_type));
+
+	state_fd = container_of(state, struct kvsfs_state_fd, state);
+	obj = container_of(obj_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+
+	switch(state->state_type) {
+	case STATE_TYPE_LOCK:
+		/* A lock state has an associated open state which will be
+		 * closed later.
+		 */
+		assert(kvsfs_file_state_invariant_closed(&state_fd->kvsfs_fd));
+		break;
+
+	case STATE_TYPE_SHARE:
+		/* This state type is an actual open file. Let's close it. */
+		assert(kvsfs_file_state_invariant_open(&state_fd->kvsfs_fd));
+		result = kvsfs_file_state_close(&state_fd->kvsfs_fd, obj);
+		if (FSAL_IS_SUCCESS(result)) {
+			result = kvsfs_delete_on_close(obj_hdl);
+		}
+		break;
+
+	case STATE_TYPE_DELEG:
+		T_TRACE("Closing Delegation state: %d, %d",
+			(int) state->state_data.deleg.sd_type,
+			(int) state->state_data.deleg.sd_state);
+		break;
+	case STATE_TYPE_LAYOUT:
+		/* Unsupported (yet) state types. */
+		gtbl_layout_rmv_elem((const struct kvsfs_file_handle *) obj->handle);
+		T_TRACE("%s", "Closing layout state");
+		break;
+
+	case STATE_TYPE_NLM_LOCK:
+	case STATE_TYPE_NLM_SHARE:
+	case STATE_TYPE_9P_FID:
+	case STATE_TYPE_NONE:
+		/* They will never be supported. */
+		assert(0); // Unreachable
+		break;
+	}
+
+	T_EXIT0(result.major);
+	return result;
+}
+
+/******************************************************************************/
+/* FSAL.close */
+/* We don't support NFSv3 but NFS Ganesha still might want to close() a file
+ * descriptior instead of a file state, for instance when finalizing
+ * an export.
+ */
+static fsal_status_t kvsfs_close(struct fsal_obj_handle *obj_hdl)
+{
+	T_ENTER(">>> (obj=%p)", obj_hdl);
+	/* Nothing to do because do not support NFSv3 OPEN */
+	T_EXIT0(-1);
+	return fsalstat(ERR_FSAL_NOT_OPENED, 0);
+}
+
+/******************************************************************************/
+/* FSAL.read2 */
+/* (copied from NFS Ganesha fsal_api)
+ * @brief Read data from a file
+ *
+ * This function reads data from the given file. The FSAL must be able to
+ * perform the read whether a state is presented or not. This function also
+ * is expected to handle properly bypassing or not share reservations.  This is
+ * an (optionally) asynchronous call.  When the I/O is complete, the done
+ * callback is called with the results.
+ *
+ * @param[in]     obj_hdl	File on which to operate
+ * @param[in]     bypass	If state doesn't indicate a share reservation,
+ *				bypass any deny read
+ * @param[in,out] done_cb	Callback to call when I/O is done
+ * @param[in,out] read_arg	Info about read, passed back in callback
+ * @param[in,out] caller_arg	Opaque arg from the caller for callback
+ *
+ * @return Nothing; results are in callback
+ */
+static void kvsfs_read2(struct fsal_obj_handle *obj_hdl,
+			bool bypass,
+			fsal_async_cb done_cb,
+			struct fsal_io_arg *read_arg,
+			void *caller_arg)
+{
+	struct kvsfs_fsal_obj_handle *obj;
+	struct kvsfs_file_state *fd;
+	uint64_t offset;
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+	fsal_status_t result;
+	ssize_t nb_read;
+	void *buffer;
+	size_t buffer_size;
+
+	/* We support only NFSv4 clients. kvsfs_open2 won't allow
+	 * an NFSv3 client to open file, therefore we won't end up here
+	 * in this case. Ergo, the following check is an assert precondition
+	 * but not an input parameter check.
+	 */
+	assert(read_arg->state);
+
+	/* Since we don't support NFSv3, we cannot handle READ_PLUS.
+	 * Note: do not confuse it with the NFSv4.2 READ_PLUS - it is not yet
+	 * implemented in NFS Ganesha.
+	 * */
+	assert(read_arg->info == NULL);
+
+	T_ENTER(">>> (%p, %p)", obj_hdl, read_arg->state);
+
+	T_TRACE("READ: off=%llu, cnt=%llu, len=%llu",
+		(unsigned long long) read_arg->offset,
+		(unsigned long long) read_arg->iov_count,
+		(unsigned long long) read_arg->iov[0].iov_len);
+
+	/* NFS Ganesha uses only a single buffer so far. */
+	assert(read_arg->iov_count == 1);
+
+	obj = container_of(obj_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+
+	result = kvsfs_find_fd(read_arg->state, bypass, FSAL_O_READ, &fd);
+	if (FSAL_IS_ERROR(result)) {
+		goto out;
+	}
+
+	buffer = read_arg->iov[0].iov_base;
+	buffer_size = read_arg->iov[0].iov_len;
+	offset = read_arg->offset;
+
+	nb_read = cfs_read(obj->cfs_fs, &cred, &fd->cfs_fd,
+			   buffer, buffer_size, offset);
+	if (nb_read < 0) {
+		result = fsalstat(posix2fsal_error(-nb_read), -nb_read);
+		goto out;
+	}
+
+	read_arg->io_amount = nb_read;
+
+	read_arg->end_of_file = (read_arg->io_amount == 0);
+
+	result = fsalstat(ERR_FSAL_NO_ERROR, 0);
+out:
+	T_EXIT0(result.major);
+	done_cb(obj_hdl, result, read_arg, caller_arg);
+}
+
+/******************************************************************************/
+/* TODO:CORTXFS: a dummy implementation of FSYNC call */
+static int cfs_fsync(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *ino)
+{
+	(void) cfs_fs;
+	(void) cred;
+	(void) ino;
+	return 0;
+}
+
+/******************************************************************************/
+/* Atomicaly modifies the size of a file and its stats.
+ * @see https://tools.ietf.org/html/rfc7530#section-16.32.
+ * TODO:EOS-914: Not implemented yet.
+ */
+static fsal_status_t kvsfs_ftruncate(struct fsal_obj_handle *obj_hdl,
+				     struct state_t *state, bool bypass,
+				     struct stat *new_stat, int new_stat_flags)
+{
+	int rc;
+	fsal_status_t result = fsalstat(ERR_FSAL_NO_ERROR, 0);
+	struct kvsfs_file_state *fd = NULL;
+	struct kvsfs_fsal_obj_handle *obj = NULL;
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+
+	T_ENTER0;
+
+	assert(obj_hdl != NULL);
+	assert((new_stat_flags & STAT_SIZE_SET) != 0);
+	assert(obj_hdl->type == REGULAR_FILE);
+
+	/* Check if there is an open state which has O_WRITE openflag
+	 * set.
+	 */
+	result = kvsfs_find_fd(state, bypass, FSAL_O_WRITE, &fd);
+	if (FSAL_IS_ERROR(result)) {
+		goto out;
+	}
+	assert(fd != NULL);
+
+	obj = container_of(obj_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+
+	rc = cfs_truncate(obj->cfs_fs, &cred, &fd->cfs_fd.ino,
+			  new_stat, new_stat_flags);
+	if (rc != 0) {
+		result = fsalstat(posix2fsal_error(-rc), -rc);
+		goto out;
+	}
+
+out:
+	T_EXIT0(result.major);
+	return result;
+}
+
+/******************************************************************************/
+/* FSAL.write2 */
+/* (copied from NFS Ganesha fsal_api)
+ * @brief Write data to a file
+ *
+ * This function writes data to a file. The FSAL must be able to
+ * perform the write whether a state is presented or not. This function also
+ * is expected to handle properly bypassing or not share reservations. Even
+ * with bypass == true, it will enforce a mandatory (NFSv4) deny_write if
+ * an appropriate state is not passed).
+ *
+ * The FSAL is expected to enforce sync if necessary.
+ *
+ * This is an (optionally) asynchronous call.  When the I/O is complete, the @a
+ * done_cb callback is called.
+ *
+ * @param[in]     obj_hdl       File on which to operate
+ * @param[in]     bypass        If state doesn't indicate a share reservation,
+ *                              bypass any non-mandatory deny write
+ * @param[in,out] done_cb	Callback to call when I/O is done
+ * @param[in,out] write_arg	Info about write, passed back in callback
+ * @param[in,out] caller_arg	Opaque arg from the caller for callback
+ */
+static void kvsfs_write2(struct fsal_obj_handle *obj_hdl,
+			 bool bypass,
+			 fsal_async_cb done_cb,
+			 struct fsal_io_arg *write_arg,
+			 void *caller_arg)
+{
+	struct kvsfs_fsal_obj_handle *obj;
+	struct kvsfs_file_state *fd;
+	uint64_t offset;
+	cfs_cred_t cred = CFS_CRED_INIT_FROM_OP;
+	fsal_status_t result;
+	ssize_t nb_write;
+	void *buffer;
+	size_t buffer_size;
+	int rc;
+
+	/* TODO: A temporary solution for keeping metadata (stat) consistent.
+	 * The lock allows us to serialize all WRITE requests ensuring
+	 * that stat is always updated in accordance with the amount
+	 * of written data.
+	 * See EOS-1424 for details.
+	 */
+	PTHREAD_RWLOCK_wrlock(&obj_hdl->obj_lock);
+
+	/* We support only NFSv4 clients. kvsfs_open2 won't allow
+	 * an NFSv3 client to open file, therefore we won't end up here
+	 * in this case. Ergo, the following check is an assert precondition
+	 * but not an input parameter check.
+	 */
+	assert(write_arg->state);
+	/* Since we don't support NFSv3, we cannot handle WRITE_PLUS */
+	assert(write_arg->info == NULL);
+
+	T_ENTER(">>> (%p, %p)", obj_hdl, write_arg->state);
+	T_TRACE("WRITE: stable=%d, off=%llu, cnt=%llu, len=%llu",
+		(int) write_arg->fsal_stable,
+		(unsigned long long) write_arg->offset,
+		(unsigned long long) write_arg->iov_count,
+		(unsigned long long) write_arg->iov[0].iov_len);
+
+	/* So far, NFS Ganesha always sends only a single buffer in a FSAL.
+	 * We can use this information for keeping write2 implementation
+	 * simple, i.e. there is no need to implement pwritev-like call
+	 * at the cortxfs layer.
+	 * The following pre-condition helps us to make sure that
+	 * NFS Ganesha still uses the same scheme.
+	 */
+	assert(write_arg->iov_count == 1);
+
+	obj = container_of(obj_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+	result = kvsfs_find_fd(write_arg->state, bypass, FSAL_O_WRITE, &fd);
+	if (FSAL_IS_ERROR(result)) {
+		goto out;
+	}
+
+	buffer = write_arg->iov[0].iov_base;
+	buffer_size = write_arg->iov[0].iov_len;
+	offset = write_arg->offset;
+
+	nb_write = cfs_write(obj->cfs_fs, &cred, &fd->cfs_fd,
+			     buffer, buffer_size, offset);
+	if (nb_write < 0) {
+		result = fsalstat(posix2fsal_error(-nb_write), -nb_write);
+		goto out;
+	}
+
+	write_arg->io_amount = nb_write;
+
+	if (write_arg->fsal_stable) {
+		nb_write = cfs_fsync(obj->cfs_fs, &cred,
+				     kvsfs_fh_to_ino(obj->handle));
+		if (nb_write < 0) {
+			write_arg->fsal_stable = false;
+			result = fsalstat(posix2fsal_error(-nb_write), -nb_write);
+			goto out;
+		}
+	}
+
+	result = fsalstat(ERR_FSAL_NO_ERROR, 0);
+out:
+	T_EXIT0(result.major);
+	PTHREAD_RWLOCK_unlock(&obj_hdl->obj_lock);
+	done_cb(obj_hdl, result, write_arg, caller_arg);
+}
+
+/******************************************************************************/
+/* FSAL.commit2 */
+/* TODO:CORTXFS does not support fsync() call, it always uses sync operations */
+static fsal_status_t kvsfs_commit2(struct fsal_obj_handle *obj_hdl,
+				   off_t offset, size_t len)
+{
+	T_ENTER0;
+	(void) obj_hdl;
+	(void) offset;
+	(void) len;
+	T_EXIT0(0);
+	return fsalstat(ERR_FSAL_NO_ERROR, 0);
+}
+
+/******************************************************************************/
+void kvsfs_handle_ops_init(struct fsal_obj_ops *ops)
+{
+	fsal_default_obj_ops_init(ops);
+
+	// Namespace
+	ops->release = release;
+	ops->lookup = kvsfs_lookup;
+	ops->readdir = kvsfs_readdir;
+	ops->mkdir = kvsfs_mkdir;
+	/* mknode is unsupported by KVSFS */
+
+	ops->symlink = kvsfs_makesymlink;
+	ops->readlink = kvsfs_readsymlink;
+
+	ops->getattrs = kvsfs_getattrs;
+	ops->setattr2 = kvsfs_setattrs;
+	ops->link = kvsfs_linkfile;
+	ops->rename = kvsfs_rename;
+	ops->unlink = kvsfs_remove;
+
+	// Protocol
+	ops->handle_to_wire = kvsfs_handle_digest;
+	ops->handle_to_key = kvsfs_handle_to_key;
+
+	// File state
+	ops->open2 = kvsfs_open2;
+	ops->status2 = kvsfs_status2;
+	ops->close2 = kvsfs_close2;
+	ops->close = kvsfs_close;
+	ops->reopen2 = kvsfs_reopen2;
+
+	// File IO
+	ops->read2 = kvsfs_read2;
+	ops->write2 = kvsfs_write2;
+	ops->commit2 = kvsfs_commit2;
+
+	/* ops->lock_op2 is not implemented because this FSAl relies on
+	 * NFS Ganesha byte-range lock handling.
+	 * However, we might add lock_op2 implementation (and enable it in
+	 * in the config) if we want to be able support locking of files
+	 * outside of NFS Ganesha or just to get additional logging
+	 * at the FSAL level.
+	 * See EOS-34 for details.
+	 */
+
+	ops->lease_op2 = kvsfs_lease_op2;
+   handle_ops_pnfs(ops);
+	/* TODO:PORTING: Disable xattrs support */
+#if 0
+	/* xattr related functions */
+	ops->list_ext_attrs = kvsfs_list_ext_attrs;
+	ops->getextattr_id_by_name = kvsfs_getextattr_id_by_name;
+	ops->getextattr_value_by_name = kvsfs_getextattr_value_by_name;
+	ops->getextattr_value_by_id = kvsfs_getextattr_value_by_id;
+	ops->setextattr_value = kvsfs_setextattr_value;
+	ops->setextattr_value_by_id = kvsfs_setextattr_value_by_id;
+	ops->getextattr_attrs = kvsfs_getextattr_attrs;
+	ops->remove_extattr_by_id = kvsfs_remove_extattr_by_id;
+	ops->remove_extattr_by_name = kvsfs_remove_extattr_by_name;
+#endif
+}

--- a/cortx-fs-ganesha/src/FSAL/FSAL_CORTXFS/main.c
+++ b/cortx-fs-ganesha/src/FSAL/FSAL_CORTXFS/main.c
@@ -1,0 +1,342 @@
+/*
+ * vim:noexpandtab:shiftwidth=8:tabstop=8:
+ *
+ * Copyright (C) Panasas Inc., 2011
+ * Author: Jim Lieb jlieb@panasas.com
+ *
+ * contributeur : Philippe DENIEL   philippe.deniel@cea.fr
+ *                Thomas LEIBOVICI  thomas.leibovici@cea.fr
+ *
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ * -------------
+ */
+
+/* Implementation of FSAL module functions for CORTXFS library.  */
+
+#include <limits.h>
+#include <fsal_types.h>
+#include <FSAL/fsal_init.h>
+#include "fsal_internal.h"
+#include <cortxfs.h>
+
+
+/* TODO:ATTR4_SEC_LABEL are not supported yet. */
+#define KVSFS_SUPPORTED_ATTRIBUTES ((const attrmask_t) (ATTRS_POSIX | ATTR_ACL ))
+
+#define KVSFS_LINK_MAX         CFS_MAX_LINK
+#define FSAL_NAME              "CORTX-FS"
+#define DBUS_INTERFACE_NAME    "org.ganesha.nfsd.config.fsal.cortxfs"
+
+const char module_name[] = FSAL_NAME;
+
+/* default parameters for CORTXFS filesystem */
+static const struct fsal_staticfsinfo_t default_kvsfs_info = {
+	.maxfilesize	= INT64_MAX,		/*< maximum allowed filesize     */
+	.maxlink	= KVSFS_LINK_MAX,	/*< maximum hard links on a file */
+	.maxnamelen	= NAME_MAX,		/*< maximum name length */
+	.maxpathlen	= PATH_MAX,		/*< maximum path length */
+	.no_trunc	= true,			/*< is it errorneous when name>maxnamelen? */
+	.chown_restricted = true,		/*< is chown limited to super-user. */
+	.case_insensitive = false,		/*< case insensitive FS? */
+	.case_preserving = true,		/*< FS preserves case? */
+	.link_support	= true,			/*< FS supports hardlinks? */
+	.symlink_support = true,		/*< FS supports symlinks? */
+	.lock_support	= false,		/*< FS supports file locking? Intentionally disabled, see EOS-34. */
+	.lock_support_async_block = false,	/*< FS supports blocking locks? Intentionally disabled, see EOS-34. */
+	.named_attr	= false,		/*< FS supports named attributes. */ /* TODO */
+	.unique_handles = true,			/*< Handles are unique and persistent. */
+	.acl_support	= FSAL_ACLSUPPORT_ALLOW,	/*< what type of ACLs are supported */ /* TODO */
+	.cansettime	= true,			/*< Is it possible to change file times using SETATTR. */
+	.homogenous	= true,	/*< Are supported attributes the same for all objects of this filesystem. */
+	.supported_attrs = KVSFS_SUPPORTED_ATTRIBUTES,	/*< If the FS is homogenous,
+							  this indicates the set of
+							  supported attributes. */
+	.maxread = FSAL_MAXIOSIZE,	/*< Max read size */
+	.maxwrite = FSAL_MAXIOSIZE,	/*< Max write size */
+	.umask = 0,		/*< This mask is applied to the mode of created
+				   objects */
+	.auth_exportpath_xdev = false,	/*< This flag indicates weither
+					   it is possible to cross junctions
+					   for resolving an NFS export path. */
+	.delegations = FSAL_OPTION_FILE_DELEGATIONS,	/*< fsal supports delegations */ /* TODO */
+	.pnfs_mds = false,		/*< fsal supports file pnfs MDS */ /* TODO */
+	.pnfs_ds = false,		/*< fsal supports file pnfs DS */ /* TODO */
+	.fsal_trace = false,		/*< fsal trace supports */ /* TBD */
+	.fsal_grace = false,		/*< fsal will handle grace */ /* TBD */
+	.link_supports_permission_checks = true,
+	.rename_changes_key = false,	/*< Handle key is changed across rename */
+	.compute_readdir_cookie = false, /* NOTE: CORTXFS is not able to produce a stable
+					    offset for given filename
+					    */
+	.whence_is_name = false,		/* READDIR uses filename instead of offset
+						TODO: update readdir implementation */
+	.readdir_plus = false,	/*< FSAL supports readdir_plus */
+	.expire_time_parent = -1, /*< Expiration time interval in
+				       seconds for parent handle.
+				       If FS gives information about parent
+				       change for a directory with an upcall,
+				       set this to -1. Else set it to some
+				       positive value. Defaults to -1. */ /* TODO: implement upcall */
+};
+
+static struct config_item kvsfs_params[] = {
+	CONF_ITEM_BOOL("link_support", true,
+		       kvsfs_fsal_module, fs_info.link_support),
+	CONF_ITEM_BOOL("symlink_support", true,
+		       kvsfs_fsal_module, fs_info.symlink_support),
+	CONF_ITEM_BOOL("cansettime", true,
+		       kvsfs_fsal_module, fs_info.cansettime),
+	CONF_ITEM_UI32("maxread", 512, FSAL_MAXIOSIZE, FSAL_MAXIOSIZE,
+		       kvsfs_fsal_module, fs_info.maxread),
+	CONF_ITEM_UI32("maxwrite", 512, FSAL_MAXIOSIZE, FSAL_MAXIOSIZE,
+		       kvsfs_fsal_module, fs_info.maxwrite),
+	CONF_ITEM_MODE("umask", 0,
+		       kvsfs_fsal_module, fs_info.umask),
+	CONF_ITEM_BOOL("auth_xdev_export", false,
+		       kvsfs_fsal_module, fs_info.auth_exportpath_xdev),
+	CONF_ITEM_BOOL("pnfs_ds", true,
+			kvsfs_fsal_module, fs_info.pnfs_ds),
+	CONF_ITEM_BOOL("pnfs_mds", true,
+			kvsfs_fsal_module, fs_info.pnfs_mds),        
+	CONFIG_EOL
+};
+
+struct config_block kvsfs_param = {
+	.dbus_interface_name = DBUS_INTERFACE_NAME,
+	.blk_desc.name = FSAL_NAME,
+	.blk_desc.type = CONFIG_BLOCK,
+	.blk_desc.u.blk.init = noop_conf_init,
+	.blk_desc.u.blk.params = kvsfs_params,
+	.blk_desc.u.blk.commit = noop_conf_commit
+};
+
+/* Init FSAL from config file */
+static fsal_status_t kvsfs_init_config(struct fsal_module *fsal_hdl,
+				     config_file_t config_struct,
+				     struct config_error_type *err_type)
+{
+	int rc = 0;
+	struct kvsfs_fsal_module *kvsfs =
+	    container_of(fsal_hdl, struct kvsfs_fsal_module, fsal);
+
+	assert(kvsfs_config_ops());
+
+	/* set default values */
+	kvsfs->fs_info = default_kvsfs_info;
+
+	/* load user values and exit upon encountering critical problems */
+	rc = load_config_from_parse(config_struct, &kvsfs_param, kvsfs,
+				    true, err_type);
+	if (rc == -1) {
+		if (!config_error_is_harmless(err_type)) {
+			LogCrit(COMPONENT_FSAL, "Detected a major error"
+				 "in the config file.");
+			rc = -EINVAL;
+			goto out;
+		} else {
+			LogMajor(COMPONENT_FSAL, "Detected an error"
+				 "in the config file. Please check KVSFS "
+				 "section for correctness of the settings.");
+			rc = 0;
+		}
+	}
+
+	gtbl_ini();
+	/**
+	 * TODO: In future when we move away from using ganesha.conf file
+	 * for the pNFS params and start using the /etc/cortx/cortxfs.conf
+	 * file, that change needs to be done from here
+	 * Initialize KVSFS FSAL obj's pNFS module
+	 */
+	rc = kvsfs_pmds_ini(kvsfs, kvsfs_params);
+	if (rc == -1) {
+		LogCrit(COMPONENT_FSAL, "Failed to load pNFS config");
+		rc = -EINVAL;
+		goto out;
+	}
+
+	/* assign the final values to the base structure */
+	fsal_hdl->fs_info = kvsfs->fs_info;
+
+	/* print final values in the log */
+	display_fsinfo(fsal_hdl);
+
+	rc = cfs_init(CFS_DEFAULT_CONFIG, kvsfs_config_ops());
+	if (rc) {
+		LogCrit(COMPONENT_FSAL, "Cannot initialize CORTXFS (%d).", rc);
+		goto out;
+	}
+
+out:
+	LogInfo(COMPONENT_FSAL, "Initialized KVSFS config (%d).", rc);
+	return fsalstat(posix2fsal_error(-rc), -rc);
+}
+
+/* KVSFS singleton */
+struct kvsfs_fsal_module KVSFS;
+
+static int kvsfs_unload(struct fsal_module *fsal_hdl);
+static void kvsfs_load(void);
+
+/*
+ * What is the problem with dlopen/dlclose?
+ * ------------------------------------------------
+ *
+ *  This section describes why we cannot use the default mechanism
+ *  for load/unload of our FSAL.
+ *  The default way of loading an FSAL is when NFS Ganesha
+ *  calls dlopen() and the corresponding "constructor"
+ *  (a function defined with __attribute__((constructor))) is getting
+ *  called within the scope of this dlopen() call.
+ *  The default way of unloading is when NFS Ganesha calls dlclose()
+ *  and the corresponding function (defined with "destructor" attribute)
+ *  is getting called within this call.
+ *  These calls are not friendly to C TLS and libc:
+ *
+ * dlopen ->
+ *	glibc takes a global lock (let's say g_mtx) and calls the ctor
+ *		ctor kvsfs_load ->
+ *			some 3d-party code is trying to
+ *			use a C TLS variable (declared with __thread).
+ *			glibc is trying initialize the variable
+ *			and takes the global lock g_mtx.
+ *			We got a deadlock.
+ *
+ *  dlopen/close also create problems with enabled/disabled jemalloc
+ *  because it either involves different allocators (glibc and jemalloc)
+ *  or the same troubles with this global lock for TLS.
+ *  Either way, dlopen/dlclose should not be used for initialization/
+ *  de-initialization of our library.
+ *
+ *
+ * Solution for init/fini problem
+ * ------------------------------
+ *
+ *  FSAL Initialization. When an FSAL was not able to initialize
+ *  during dlopen() call, NFS Ganesha uses "fsal_init" symbol as
+ *  a backup mechanism to initialize the FSAL: it looks it up and then
+ *  calls it.
+ *
+ *  FSAL Finalization. NFS Ganesha provides the default implementation
+ *  of the FSAL.unload callback. The function calls dlclose() which
+ *  causes the "dtor" to be called. Since we don't want to use a dtor,
+ *  we simply overwrite the default callback with our own function.
+ *  Our function is called outside of dlclose(), so that we have no
+ *  problems.
+ *
+ *  TODO: This overwriting of FSAL.unload leads to the situation where
+ *  dlclose() is not called (as well as the ref count and the list of FSALs
+ *  are not getting updated). Once we achieve the point where we are able to
+ *  successfully terminate NFS Ganesha (without getting SIGABRT or SIGSEGV),
+ *  we need to investigate if these things needs to be updated. For example,
+ *  we can preserve the original callback pointer, and we can call it when
+ *  our own "fini" call is done its work.
+ */
+
+/* This symbol has to be public (visible). NFS Ganesha uses it to load an FSAL
+ * when the load-on-dlopen way does not work.
+ * We do not use this dlopen+ctor trick because it plays very bad with
+ * 3dparty libraries that use C TLS (for example, jemalloc or libuuid).
+ * The same principle is applied to finalization. Previously we had
+ * a combination of dclose+dtor which would finalize the FSAL when
+ * dlclose is called. It also creates problems with C TLS. The solution
+ * here is to use the FSAL.unload interface function let NFS Ganesha
+ * call this function before dlclose is called.
+ *
+ * NOTE: Due to the collision between "fsal_init" symbol used
+ * in NFS Ganesha ::load_fsal function and the function ::fsal_init
+ * (see fsal_manager.c) that is declared in the global scope,
+ * we cannot define our FSAL init function with the right
+ * signature (void (*)(void)), and instead we have to use
+ * the existing signature. It is safe as long as we don't
+ * use the unused arguments.
+ */
+void *fsal_init(void *unused1, void *unused2)
+{
+	(void) unused1;
+	(void) unused2;
+
+	kvsfs_load();
+	return NULL;
+}
+
+static void kvsfs_load(void)
+{
+	int rc;
+	struct fsal_module *myself = &KVSFS.fsal;
+
+	rc = register_fsal(myself, module_name,
+			   FSAL_MAJOR_VERSION,
+			   FSAL_MINOR_VERSION,
+			   FSAL_ID_EXPERIMENTAL);
+	if (rc) {
+		LogCrit(COMPONENT_FSAL, "KVSFS FSAL module failed to "
+			"register iself (%d).", rc);
+		goto out;
+	}
+
+	/* Set up module operations */
+	myself->m_ops.create_export = kvsfs_create_export;
+
+	/* Set up module parameters */
+	myself->m_ops.init_config = kvsfs_init_config;
+	myself->m_ops.unload = kvsfs_unload;
+
+	/* Set up pNFS operations */
+	 myself->m_ops.fsal_pnfs_ds_ops = kvsfs_pnfs_ds_ops_init;
+	 myself->m_ops.getdeviceinfo = kvsfs_getdeviceinfo;
+
+	/* Initialize fsal_obj_handle for FSAL */
+	kvsfs_handle_ops_init(&KVSFS.handle_ops);
+
+out:
+	LogDebug(COMPONENT_FSAL, "FSAL KVSFS initialized (%d)", rc);
+	return;
+}
+
+static int kvsfs_unload(struct fsal_module *fsal_hdl)
+{
+	int rc = 0;
+
+	assert(fsal_hdl == &KVSFS.fsal);
+
+	rc = unregister_fsal(&KVSFS.fsal);
+	if (rc) {
+		LogCrit(COMPONENT_FSAL, "KVSFS FSAL module failed to"
+			" unregister itself (%d).", rc);
+		goto out;
+	}
+
+	gtbl_fini();
+
+	rc = cfs_fini();
+	if (rc) {
+		LogCrit(COMPONENT_FSAL, "cfs_fini failed (%d)", rc);
+		goto out;
+	}
+
+	rc = kvsfs_pmds_fini(&KVSFS);
+	if (rc) {
+		LogCrit(COMPONENT_FSAL, "kvsfs_pmds_fini() failed (%d)", rc);
+		goto out;
+	}
+
+out:
+	LogDebug(COMPONENT_FSAL, "FSAL KVSFS deinitialized (%d)", rc);
+	return rc;
+}
+

--- a/cortx-fs-ganesha/src/FSAL/FSAL_CORTXFS/mds.c
+++ b/cortx-fs-ganesha/src/FSAL/FSAL_CORTXFS/mds.c
@@ -1,0 +1,1159 @@
+/*
+ * Filename:         mds.c
+ * Description:      FSAL CORTXFS's pNFS MetaData Server operations
+
+ * Do NOT modify or remove this copyright and confidentiality notice!
+ * Copyright (c) 2020, Seagate Technology, LLC.
+ * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
+ * Portions are also trade secret. Any use, duplication, derivation,
+ * distribution or disclosure of this code, for any reason, not expressly
+ * authorized is prohibited. All other rights are expressly reserved by
+ * Seagate Technology, LLC.
+
+ This file contains CORTXFS's pNFS MDS implementation
+*/
+
+/*
+ *
+ * vim:noexpandtab:shiftwidth=8:tabstop=8:
+ *
+ * Copyright © 2012 CohortFS, LLC.
+ * Author: Adam C. Emerson <aemerson@linuxbox.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ *
+ */
+
+#include "config.h"
+
+#include <assert.h>
+#include <libgen.h>		/* used for 'dirname' */
+#include <pthread.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+#include <mntent.h>
+#include "gsh_list.h"
+#include "fsal.h"
+#include "fsal_internal.h"
+#include "fsal_convert.h"
+#include "FSAL/fsal_config.h"
+#include "FSAL/fsal_commonlib.h"
+#include "kvsfs_methods.h"
+#include "nfs_exports.h"
+#include "nfs_creds.h"
+#include "pnfs_utils.h"
+#include <stdbool.h>
+#include <arpa/inet.h>
+
+/* Wrappers for KVSFS handle debug traces. Enable this "#if" if you want
+ * to get traces even without enabled DEBUG logging level, i.e. if you want to
+ * see only debug logs from this module.
+ */
+
+#if 1
+#define T_ENTER(_fmt, ...) \
+	LogCrit(COMPONENT_PNFS, "T_ENTER " _fmt, __VA_ARGS__)
+
+#define T_EXIT(_fmt, ...) \
+	LogCrit(COMPONENT_PNFS, "T_EXIT " _fmt, __VA_ARGS__)
+
+#define T_TRACE(_fmt, ...) \
+	LogCrit(COMPONENT_PNFS, "T_TRACE " _fmt, __VA_ARGS__)
+#else
+#define T_ENTER(_fmt, ...) \
+	LogDebug(COMPONENT_PNFS, "T_ENTER " _fmt, __VA_ARGS__)
+
+#define T_EXIT(_fmt, ...) \
+	LogDebug(COMPONENT_PNFS, "T_EXIT " _fmt, __VA_ARGS__)
+
+#define T_TRACE(_fmt, ...) \
+	LogDebug(COMPONENT_PNFS, "T_TRACE " _fmt, __VA_ARGS__)
+#endif
+
+#define T_ENTER0 T_ENTER(">>> %s", "()");
+#define T_EXIT0(__rcval)  T_EXIT("<<< rc=%d", __rcval);
+
+extern struct kvsfs_fsal_module KVSFS;
+
+/* FSAL_CORTXFS currently supports only LAYOUT4_NFSV4_1_FILES */
+#define SUPPORTED_LAYOUT_TYPE LAYOUT4_NFSV4_1_FILES
+
+/*  Only 4MB as of now */
+#define SUPPORTED_LAYOUT_BLOCK_SIZE 0x400000U
+
+/* Since current clients only support 1, that's what we'll use. */
+#define SUPPORTED_LAYOUT_MAX_SEGMENTS 1U
+
+#define SUPPORTED_LAYOUT_LOC_BODY_SIZE 0x100U
+
+#define SUPPORTED_LAYOUT_DA_ADDR_SIZE 0x1400U
+
+#define KVSFS_PNFS_MIN_STRIPE_COUNT 1U
+#define KVSFS_PNFS_MAX_HOST_COUNT 3U
+
+/**
+ * 1. If kvsfs_fsal_obj_handle.pnfs_role == PNFS_DISABLED:
+ * 	kvsfs_fsal_obj_handle.mds_ctx == NULL
+ *
+ * 2. If kvsfs_fsal_obj_handle.pnfs_role == PNFS_MDS:
+ * 	kvsfs_fsal_obj_handle.mds_ctx != NULL
+ * 	kvsfs_pnfs_mds_ctx.num_ds >= 0
+ * 	kvsfs_pnfs_mds_ctx.num_ds reflects no. of nodes in
+ * 		kvsfs_pnfs_mds_ctx.mds_ds_list
+ *
+ * 3. If kvsfs_fsal_obj_handle.pnfs_role == PNFS_DS:
+ * 	kvsfs_fsal_obj_handle.mds_ctx == NULL
+ *
+ * 4. If kvsfs_fsal_obj_handle.pnfs_role == PNFS_BOTH:
+ * 	conditions for 2 applicable, addition to that:
+ * 	kvsfs_pnfs_mds_ctx.mds_ds_list must have atleast one elem, i.e. self
+ */
+
+enum kvsfs_pNFS_server_role {
+	KVSFS_PNFS_DISABLED = 0,
+	KVSFS_PNFS_DS,
+	KVSFS_PNFS_MDS,
+	KVSFS_PNFS_BOTH
+};
+
+struct kvsfs_pnfs_ds_addr {
+	uint16_t ds_addr_id;
+	uint16_t ds_addr_ref;
+	in_port_t ds_ip_port;
+	sockaddr_t ds_ip_addr;
+	LIST_ENTRY(kvsfs_pnfs_ds_addr) ds_addr_link;
+};
+
+/**
+ * TODO: when layout states will be maintained in future and dynamic DS list
+ * will be supported, a DS entry should be protected with 'ds_ref' from
+ * deletion. Same is applicable for 'ds_addr_ref' as well.
+ * 'ds_id, ds_ref, ds_addr_id and ds_addr_ref' are for future use.
+ */
+struct kvsfs_pnfs_ds_info {
+	uint16_t ds_id;
+	uint16_t ds_ref;
+	LIST_HEAD(kvsfs_pnfs_ds_addr_list, kvsfs_pnfs_ds_addr) ds_addr_list;
+	LIST_ENTRY(kvsfs_pnfs_ds_info) ds_link;
+};
+
+struct kvsfs_pnfs_mds_info {
+	uint32_t stripe_unit;
+	LIST_HEAD(kvsfs_pnfs_ds_info_list, kvsfs_pnfs_ds_info) mds_ds_list;
+	uint16_t num_ds;
+	struct kvsfs_pnfs_ds_info *mds_next_ds;
+};
+
+struct kvsfs_pnfs_mds_ctx {
+	uint32_t pnfs_role;
+	pthread_mutex_t mds_mutex;
+	struct kvsfs_pnfs_mds_info *mds;
+};
+
+// TODO: We should use cortxfs_gtbl_elm_layout in future instead of kvsfs_file_handle
+struct cortxfs_gtbl_elm_layout {
+	struct kvsfs_file_handle lt_fh;
+	uint64_t lt_offset;
+	uint64_t lt_length;
+	struct kvsfs_file_state *lt_fd;
+} __attribute__((__unused__));
+
+#define LAYOUT_TBL_HT_KEY(fh) (fh->fs_id + fh->kvsfs_handle)
+
+/**
+ * @brief Start a layout by updating global table CORTXFS_GTBL_STATE_LAYOUTS
+ *        Also used to detect conflicts.
+ *
+ * @param[in]  fh         KVSFS file handle on which layout is requested
+ * @return nfsstat4, 0 if success, else error value
+ * TODO: In future when the global open tables are completely implemented
+ *       and multiple layout to different regions of a same file object
+ *       will be supported, then we'll need to replace the kvsfs_file_handle
+ *       with cortxfs_gtbl_elm_layout, and use that for the key generation.
+ */
+
+static nfsstat4 gtbl_layout_add_elem(const struct kvsfs_file_handle *fh)
+{
+	uint64_t key;
+	struct kvsfs_file_handle *lt_fh;
+
+	dassert(fh != NULL);
+
+	lt_fh = gsh_calloc(1, sizeof(*lt_fh));
+	dassert(lt_fh != NULL);
+
+	*lt_fh = *fh;
+	key = LAYOUT_TBL_HT_KEY(lt_fh);
+
+	if (gtbl_add_elem(CORTXFS_GTBL_STATE_LAYOUTS, lt_fh,
+			  sizeof(*lt_fh), key) != 0) {
+		// conflict
+		gsh_free(lt_fh);
+		return NFS4ERR_LAYOUTTRYLATER;
+	}
+
+	return NFS4_OK;
+}
+
+/**
+ * @brief Try to remove a layout by updating global table
+ *        CORTXFS_GTBL_STATE_LAYOUTS
+ *
+ * @param[in]  fh         KVSFS file handle on which layout is expected 
+ * @return void
+ */
+
+void gtbl_layout_rmv_elem(const struct kvsfs_file_handle *fh)
+{
+	uint64_t key;
+	struct kvsfs_file_handle *lt_fh;
+
+	dassert(fh != NULL);
+
+	key = LAYOUT_TBL_HT_KEY(fh);
+	lt_fh = gtbl_remove_elem(CORTXFS_GTBL_STATE_LAYOUTS, fh,
+				 sizeof(*fh), key);
+	gsh_free(lt_fh);
+}
+
+
+/**
+ * @brief Initialize the KVSFS FSAL's global pNFS config, must be called only
+ * once while FSAL loads/starts
+ *
+ * @param[in]  kvsfs         KVSFS FSAL's global context
+ * @param[in]  kvsfs_params  Config from cortx.conf
+ * @param[out] kvsfs         pNFS config created and updated if available
+ *
+ * @return 0 if success, else negative error value
+ */
+
+
+int kvsfs_pmds_ini(struct kvsfs_fsal_module *kvsfs,
+		   const struct config_item *kvsfs_params)
+{
+	int rc = 0;
+	struct kvsfs_pnfs_mds_ctx *mds_ctx;
+
+	dassert(kvsfs != NULL);
+	dassert(kvsfs_params != NULL);
+	dassert(kvsfs->mds_ctx == NULL);
+
+	/** 
+	 * TODO: When the pNFS config is moved to cortx.conf file, process
+	 * kvsfs_params here and update kvsfs->pnfs_role and
+	 * kvsfs->mds_ctx. Until then, just initialize kvsfs->mds_ctx.
+	 * In future, initialize only if pnfs_role > KVSFS_PNFS_DS.
+	 */
+	mds_ctx = gsh_calloc(1, sizeof(*mds_ctx));
+	if (mds_ctx == NULL) {
+		LogCrit(COMPONENT_PNFS,
+			"gsh_calloc failed: %u", sizeof(*mds_ctx->mds));
+		rc = -ENOMEM;
+		goto out;
+	}
+
+	mds_ctx->pnfs_role = KVSFS_PNFS_DISABLED;
+	mds_ctx->mds = gsh_calloc(1, sizeof(struct kvsfs_pnfs_mds_info));
+	if (mds_ctx->mds == NULL) {
+		LogCrit(COMPONENT_PNFS,
+			"gsh_calloc failed: %u", sizeof(*mds_ctx->mds));
+		rc = -ENOMEM;
+		goto out;
+	}
+
+	rc = pthread_mutex_init(&mds_ctx->mds_mutex, NULL);
+	if (rc != 0) {
+		LogCrit(COMPONENT_PNFS,
+			"pthread_mutex_init failed: %x", rc);
+		goto out;
+	}
+
+	LIST_INIT(&mds_ctx->mds->mds_ds_list);
+
+out:
+	if (rc != 0) {
+		if (mds_ctx) {
+			gsh_free(mds_ctx->mds);
+		}
+		gsh_free(mds_ctx);
+	} else {
+		kvsfs->mds_ctx = mds_ctx;
+	}
+
+	return rc;
+}
+
+/**
+ * @brief Cleanup the MDS context (private helper)
+ *
+ * @param[in]  mds       MDS info
+ * @return void
+ */
+
+static void kvsfs_pmds_cleanup(struct kvsfs_pnfs_mds_info *mds)
+{
+	struct kvsfs_pnfs_ds_info *ds;
+	struct kvsfs_pnfs_ds_addr *ds_addr;
+
+	dassert(mds != NULL);
+
+	while (!LIST_EMPTY(&mds->mds_ds_list)) {
+		ds = LIST_FIRST(&mds->mds_ds_list);
+		/**
+		 * TODO: Add support for ds_ref
+		 * When a DS is being removed, then need to check if there are
+		 * any active layouts using this DS< then the mapping needs to
+		 * be updated and associated layouts needs to be recalled.
+		 */
+		LIST_REMOVE(ds, ds_link);
+		while (!LIST_EMPTY(&ds->ds_addr_list)) {
+			ds_addr = LIST_FIRST(&ds->ds_addr_list);
+			// TODO: Add support for ds_addr_refds_addr_ref
+			// Same as prev. one
+			LIST_REMOVE(ds_addr, ds_addr_link);
+			gsh_free(ds_addr);
+		}
+		gsh_free(ds);
+	}
+
+	gsh_free(mds);
+}
+
+/**
+ * @brief De-initialize the KVSFS FSAL's global pNFS config, must be called only
+ * once while FSAL unloads/stops
+ *
+ * @param[in]  kvsfs         KVSFS FSAL's global context
+ * @param[out] kvsfs         pNFS config and context removed
+ *
+ * @return 0 if success, else negative error value
+ */
+
+int kvsfs_pmds_fini(struct kvsfs_fsal_module *kvsfs)
+{
+	int rc = 0;
+
+	dassert(kvsfs != NULL);
+
+	rc = pthread_mutex_lock(&kvsfs->mds_ctx->mds_mutex);
+	if (rc != 0) {
+		LogCrit(COMPONENT_PNFS, "pthread_mutex_lock failed: %x", rc);
+		goto out;
+	}
+
+	kvsfs_pmds_cleanup(kvsfs->mds_ctx->mds);
+
+	rc = pthread_mutex_unlock(&kvsfs->mds_ctx->mds_mutex);
+	if (rc != 0) {
+		LogCrit(COMPONENT_PNFS, "pthread_mutex_unlock failed: %x", rc);
+		goto out;
+	}
+
+	rc = pthread_mutex_destroy(&kvsfs->mds_ctx->mds_mutex);
+	if (rc != 0) {
+		LogCrit(COMPONENT_PNFS, "pthread_mutex_destroy failed: %x", rc);
+		goto out;
+	}
+
+	gsh_free(kvsfs->mds_ctx);
+
+out:
+	return rc;
+}
+
+
+/**
+ * @brief Load pNFS config from export entries/override with new entries
+ *
+ * Until the global config support is added, we keep using the per-export
+ * config as of now, but only take the pNFS config from the very first export.
+ * Adding new exports/endpoints will override previous config and will cause
+ * run-time update of the in-memory pNFS config. Until HA's multi-node support
+ * is integrated, this approach can be used temporarily to simulate add-delete
+ * multiple DS dynamically.
+ * However please note that this support is not complete without implementing
+ * the references (i.e. ds_ref and ds_addr_refds_addr_ref).
+ * Note: Update will be cancelled if configuration error is encountered.
+ * Duplicate/No-op update validation is not available yet.
+ *
+ * @param[in]  kvsfs         KVSFS FSAL's global context
+ * @param[in]  exp_config    export config to use for new pNFS config
+ * @param[out] kvsfs         pNFS config and context modified 
+ *
+ * @return 0 if success, else negative error value
+ *
+ */
+
+int kvsfs_pmds_update_exp(struct kvsfs_fsal_module *kvsfs,
+			  const struct kvsfs_fsal_export *exp_config)
+{
+	int rc = 0;
+	int idx = 0;
+	uint32_t local_pnfs_role;
+	struct kvsfs_pnfs_mds_info *local_mds = NULL;
+	struct kvsfs_pnfs_ds_info *ds;
+	struct kvsfs_pnfs_ds_addr *ds_addr;
+
+	dassert(kvsfs != NULL);
+	dassert(exp_config != NULL);
+
+	local_pnfs_role = KVSFS_PNFS_DISABLED;
+
+	if (exp_config->pnfs_param.pnfs_enabled) {
+		if ((exp_config->pnfs_ds_enabled) &&
+		    (exp_config->pnfs_mds_enabled)) {
+			local_pnfs_role = KVSFS_PNFS_BOTH;
+		} else if (exp_config->pnfs_mds_enabled) {
+			local_pnfs_role = KVSFS_PNFS_MDS;
+		} else if (exp_config->pnfs_ds_enabled) {
+			local_pnfs_role = KVSFS_PNFS_DS;
+		}
+	}
+
+	if (local_pnfs_role > KVSFS_PNFS_DS) {
+		local_mds = gsh_calloc(1, sizeof(*local_mds));
+		if (local_mds == NULL) {
+			LogCrit(COMPONENT_PNFS,
+				"gsh_calloc failed: %u",
+				sizeof(*local_mds));
+			rc = -ENOMEM;
+			goto out;
+		}
+
+		local_mds->stripe_unit =
+			exp_config->pnfs_param.stripe_unit;
+
+		LIST_INIT(&local_mds->mds_ds_list);
+		local_mds->num_ds = 0;
+
+		for(idx = 0; idx < exp_config->pnfs_param.nb_ds; idx++) {
+			ds = gsh_calloc(1, sizeof(*ds));
+			if (ds == NULL) {
+				LogCrit(COMPONENT_PNFS,
+					"gsh_calloc failed: %u",
+					sizeof(*ds));
+				rc = -ENOMEM;
+				goto out;
+			}
+			/**
+			 * TODO: Once dynamic add/remove DS support is added
+			 * either via temp. config file or via HA, we will need
+			 * to design how to update and maintain ds_id
+			 */
+			ds->ds_id = idx;
+			LIST_INIT(&ds->ds_addr_list);
+
+			// per DS, only one addr as of now
+			// TODO: support for multiple addresses
+			ds_addr = gsh_calloc(1, sizeof(*ds_addr));
+			if (ds_addr == NULL) {
+				LogCrit(COMPONENT_PNFS,
+					"gsh_calloc failed: %u",
+					sizeof(*ds_addr));
+				rc = -ENOMEM;
+				goto out;
+			}
+			ds_addr->ds_addr_id =
+				exp_config->pnfs_param.ds_array[idx].id;
+			ds_addr->ds_ip_port =
+				exp_config->pnfs_param.ds_array[idx].ipport;
+			ds_addr->ds_ip_addr =
+				exp_config->pnfs_param.ds_array[idx].ipaddr;
+
+			LIST_INSERT_HEAD(&ds->ds_addr_list, ds_addr,
+					 ds_addr_link);
+
+			LIST_INSERT_HEAD(&local_mds->mds_ds_list, ds,
+					 ds_link);
+			local_mds->num_ds++;
+		}
+
+		rc = pthread_mutex_lock(&kvsfs->mds_ctx->mds_mutex);
+		if (rc != 0) {
+			LogCrit(COMPONENT_PNFS,
+				"pthread_mutex_lock failed: %x", rc);
+			goto out;
+		}
+
+		// delete the current config and commit the change
+		kvsfs_pmds_cleanup(kvsfs->mds_ctx->mds);
+
+		kvsfs->mds_ctx->pnfs_role = local_pnfs_role;
+		kvsfs->mds_ctx->mds = local_mds; 
+
+		rc = pthread_mutex_unlock(&kvsfs->mds_ctx->mds_mutex);
+		if (rc != 0) {
+			LogCrit(COMPONENT_PNFS,
+				"pthread_mutex_unlock failed: %x", rc);
+			goto out;
+		}
+	}
+
+out:
+	if (rc != 0) {
+		kvsfs_pmds_cleanup(local_mds);
+	}
+
+	return rc;
+}
+
+/**
+ * @brief Internal handler for kvsfs_getdeviceinfo()
+ * Get information about a pNFS layout's stripe to device mapping.
+ * This function always returns only one stripe as of now, i.e. only one map
+ * of a layout to a data server. Each call to this handler will traverse the
+ * global DS list of this MDS and will assign a DS with its IP addresses in a
+ * round robin manner. As of now, it does not support load balancing,
+ * in-memory or persistent device map, multiple stripes etc.
+ *
+ * @param[in]  mds_ctx       Global KVSFS FSAL's pNFS MDS context
+ * @param[in]  deviceid	     caller passed device id
+ * @param[out] stripes_nmemb array 'stripes' no. of entries, 1 as of now
+ * @param[out] stripes       array of stripes
+ * @param[out] ds_count      How many DS are being returned, 1 as of now
+ * @param[out] hosts_nmemb   per DS number of hosts, denotes the array length
+ * @param[out] hosts	     per DS array of hosts
+ *
+ * @return Valid error codes in RFC 5661, p. 365.
+ */
+
+nfsstat4
+kvsfs_pmds_getdevinfo_internal(struct kvsfs_pnfs_mds_ctx *mds_ctx,
+			       const struct pnfs_deviceid *deviceid,
+			       uint32_t *stripes_nmemb,
+			       uint32_t **stripes,
+			       uint32_t *ds_count,
+			       uint32_t *hosts_nmemb,
+			       fsal_multipath_member_t **hosts)
+{
+	nfsstat4 nfs_status = NFS4_OK;
+	struct kvsfs_pnfs_ds_info **ds;
+	struct kvsfs_pnfs_ds_addr *ds_addr;
+	unsigned long dsaddr = INADDR_NONE;
+	struct sockaddr_in6 *addr;
+	uint32_t stripes_count = KVSFS_PNFS_MIN_STRIPE_COUNT;
+	uint32_t idx = 0;
+	fsal_multipath_member_t hosts_local[KVSFS_PNFS_MAX_HOST_COUNT] = {0};
+	int rc = 0;
+
+	dassert(deviceid != NULL);
+	dassert(stripes_nmemb != NULL);
+	dassert(*stripes == NULL);
+	dassert(ds_count != NULL);
+	dassert(hosts_nmemb != NULL);
+	dassert(*hosts == NULL);
+
+	/**
+	 * Only pNFS Meta Data Server is allowed to execute this
+	 */
+	if (mds_ctx->pnfs_role < KVSFS_PNFS_MDS) {
+		LogCrit(COMPONENT_PNFS, "incorrect role: %x",
+			mds_ctx->pnfs_role);
+		nfs_status = NFS4ERR_NOTSUPP;
+		goto out;
+	}
+
+	dassert(mds_ctx->mds != NULL);
+
+	/**
+	 * Only the deviceid.fsal_id is being used currently
+	 */
+	if (deviceid->fsal_id != FSAL_ID_EXPERIMENTAL) {
+		LogCrit(COMPONENT_PNFS,
+				"deviceid.fsal_id incorrect: %x",
+				deviceid->fsal_id);
+		nfs_status = NFS4ERR_INVAL;
+		goto out;
+	}
+
+	*stripes = gsh_calloc(stripes_count, sizeof (uint32_t));
+	if (*stripes == NULL) {
+		LogCrit(COMPONENT_PNFS,
+				"gsh_calloc failed: %u",
+				stripes_count * sizeof (uint32_t));
+		nfs_status = NFS4ERR_SERVERFAULT;
+		goto out;
+	}
+
+	rc = pthread_mutex_lock(&mds_ctx->mds_mutex);
+	dassert(rc == 0);
+
+	ds = &mds_ctx->mds->mds_next_ds;
+
+	if (*ds == NULL) {
+		// get an elem
+		if (mds_ctx->mds->num_ds == 0) {
+			// consistency check
+			dassert(LIST_EMPTY(
+				&mds_ctx->mds->mds_ds_list) != True);
+			// atleast the self entry is expected for KVSFS_PNFS_BOTH
+			dassert(mds_ctx->pnfs_role != KVSFS_PNFS_BOTH);
+			LogWarn(COMPONENT_PNFS, "No DS for role: %x",
+				mds_ctx->pnfs_role);
+			nfs_status = NFS4ERR_NOENT;
+			goto unlock_out;
+		}
+		*ds = LIST_FIRST(&mds_ctx->mds->mds_ds_list);
+	} else {
+		// try to use the next one if available
+		*ds = LIST_NEXT(*ds, ds_link);
+		if (*ds == NULL) {
+			*ds = LIST_FIRST(&mds_ctx->mds->mds_ds_list);
+		}
+	}
+
+	LIST_FOREACH(ds_addr, &(*ds)->ds_addr_list, ds_addr_link) {
+		/* Ganesha parsing code in config_parsing does not store the
+		 * AF family value. Check if this is a IPV4 mapped IPV6 address,
+		 * if not, this is a V4 address.
+		 */
+		addr = (struct sockaddr_in6 *) (&ds_addr->ds_ip_addr);
+		if(IN6_IS_ADDR_V4MAPPED(&addr->sin6_addr)) {
+			/* A IPv4 mapped IPv6 address, consists of 
+			 * 80 "0" bits, followed by 16 "1" bits
+			 * followed by 32 bit IPv4 address
+			 */
+			dsaddr = ((struct in_addr *)
+					(addr->sin6_addr.s6_addr+12))->s_addr;
+			LogDebug(COMPONENT_PNFS,
+					"advertises DS addr=%u.%u.%u.%u port=%u",
+					(ntohl(dsaddr) & 0xFF000000) >> 24,
+					(ntohl(dsaddr) & 0x00FF0000) >> 16,
+					(ntohl(dsaddr) & 0x0000FF00) >> 8,
+					(unsigned int)ntohl(dsaddr) & 0x000000FF,
+					(unsigned short)(ds_addr->ds_ip_port));
+		} else {
+			// This should be a V4 address
+			LogDebug(COMPONENT_PNFS, "\n This is a v4 address\n");
+			dsaddr = ((struct sockaddr_in *)
+					(&ds_addr->ds_ip_addr))->sin_addr.s_addr;
+		}
+
+		// This should not happen
+		dassert(idx != KVSFS_PNFS_MAX_HOST_COUNT);
+
+		hosts_local[idx].proto = IPPROTO_TCP;
+		hosts_local[idx].addr = ntohl(dsaddr);
+		hosts_local[idx++].port = ds_addr->ds_ip_port;
+	}
+
+unlock_out:
+	pthread_mutex_unlock(&mds_ctx->mds_mutex);
+	dassert(rc == 0);
+
+out:
+	if (nfs_status != NFS4_OK) {
+		gsh_free(stripes);
+		gsh_free(hosts);
+	} else {
+		*hosts = gsh_calloc(idx, sizeof(**hosts));
+		if (*hosts == NULL) {
+			LogCrit(COMPONENT_PNFS,
+				"gsh_calloc failed: %u",
+				 idx * sizeof(**hosts));
+			nfs_status = NFS4ERR_SERVERFAULT;
+			goto out;
+		}
+
+		memcpy(*hosts, hosts_local, idx * sizeof(**hosts));
+		*stripes_nmemb = stripes_count;
+		// as of now, stripe:ds == 1:1
+		*ds_count = stripes_count;
+		*hosts_nmemb = idx;
+	}
+
+	return nfs_status;
+}
+
+/**
+ * @brief Get layout types supported by this FSAL
+ * Note: This is Filesystem wide
+ *
+ * We just return a pointer to the single type and set the count to 1.
+ *
+ * @param[in]  export_pub Public export handle
+ * @param[out] count      Number of layout types in array
+ * @param[out] types      Static array of layout types that must not be
+ *                        freed or modified and must not be dereferenced
+ *                        after export reference is relinquished
+ */
+static void
+kvsfs_fs_layouttypes(struct fsal_export *export_hdl,
+		      int32_t *count,
+		      const layouttype4 **types)
+{
+	static layouttype4 type = SUPPORTED_LAYOUT_TYPE;
+	*types = &type;
+	*count = 1;
+}
+
+/**
+ * @brief Get layout block size for export
+ *
+ * This function just returns the KVSFS default.
+ *
+ * @param[in] export_pub Public export handle
+ *
+ * @return 4 MB.
+ */
+static uint32_t
+kvsfs_fs_layout_blocksize(struct fsal_export *export_pub)
+{
+	return SUPPORTED_LAYOUT_BLOCK_SIZE;
+}
+
+/**
+ * @brief Maximum number of segments we will use
+ *
+ * Since current clients only support 1, that's what we'll use.
+ *
+ * @param[in] export_pub Public export handle
+ *
+ * @return 1
+ */
+static uint32_t
+kvsfs_fs_maximum_segments(struct fsal_export *export_pub)
+{
+	return SUPPORTED_LAYOUT_MAX_SEGMENTS;
+}
+
+/**
+ * @brief Size of the buffer needed for a loc_body
+ *
+ * Just a handle plus a bit.
+ *
+ * @param[in] export_pub Public export handle
+ *
+ * @return Size of the buffer needed for a loc_body
+ */
+static size_t
+kvsfs_fs_loc_body_size(struct fsal_export *export_pub)
+{
+	return SUPPORTED_LAYOUT_LOC_BODY_SIZE;
+}
+
+/**
+ * @brief Size of the buffer needed for a ds_addr
+ *
+ * This one is huge, due to the striping pattern.
+ *
+ * @param[in] export_pub Public export handle
+ *
+ * @return Size of the buffer needed for a ds_addr
+ */
+size_t kvsfs_fs_da_addr_size(struct fsal_module *fsal_hdl)
+{
+	return SUPPORTED_LAYOUT_DA_ADDR_SIZE;
+}
+
+
+
+/**
+ * @brief Get information about a pNFS device
+ *
+ * When this function is called, the FSAL should write device
+ * information to the @c da_addr_body stream.
+ *
+ * @param[in]  fsal_hdl     FSAL module
+ * @param[out] da_addr_body Stream we write the result to
+ * @param[in]  type         Type of layout that gave the device
+ * @param[in]  deviceid     The device to look up
+ *
+ * @return Valid error codes in RFC 5661, p. 365.
+ */
+
+
+nfsstat4 kvsfs_getdeviceinfo(struct fsal_module *fsal_hdl,
+			      XDR *da_addr_body,
+			      const layouttype4 type,
+			      const struct pnfs_deviceid *deviceid)
+{
+	uint32_t stripes_nmemb;
+	uint32_t *stripes = NULL;
+	uint32_t ds_count;
+	uint32_t hosts_nmemb;
+	fsal_multipath_member_t *hosts = NULL;
+	/* NFSv4 status code */
+	nfsstat4 nfs_status = NFS4_OK;
+	int idx = 0;
+
+	T_ENTER(">>> (%p, %p)", fsal_hdl, deviceid);
+	LogDebug(COMPONENT_PNFS,">> ENTER kvsfs_getdeviceinfo\n");
+
+	/* Sanity check on type */
+	if (type != LAYOUT4_NFSV4_1_FILES) {
+		LogCrit(COMPONENT_PNFS, "Unsupported layout type: %x", type);
+		nfs_status = NFS4ERR_UNKNOWN_LAYOUTTYPE;
+		T_EXIT0(nfs_status);
+		goto out;
+	}
+
+	LogDebug(COMPONENT_PNFS, "device_id %u/%u/%u %lu",
+		 deviceid->device_id1, deviceid->device_id2,
+		 deviceid->device_id4, deviceid->devid);
+
+	nfs_status = kvsfs_pmds_getdevinfo_internal(KVSFS.mds_ctx, deviceid,
+						    &stripes_nmemb,
+						    &stripes,
+						    &ds_count,
+						    &hosts_nmemb,
+						    &hosts);
+	if (nfs_status != NFS4_OK) {
+		LogCrit(COMPONENT_PNFS,
+			"kvsfs_pmds_getdevinfo_internal failed: %x",
+			nfs_status);
+		T_EXIT0(nfs_status);
+		goto out;
+	}
+
+	if (!inline_xdr_u_int32_t(da_addr_body, &stripes_nmemb)) {
+		LogCrit(COMPONENT_PNFS,
+			"Failed to encode length of stripe_indices array: %"
+			PRIu32 ".",
+			stripes_nmemb);
+		nfs_status = NFS4ERR_SERVERFAULT;
+		T_EXIT0(nfs_status);
+		goto out;
+	}
+
+	for (idx = 0; idx < stripes_nmemb; idx++) {
+		if (!inline_xdr_u_int32_t(da_addr_body, &stripes[idx])) {
+			LogCrit(COMPONENT_PNFS,
+				"Failed to encode OSD for stripe %u.%u",
+				idx, stripes[idx]);
+			nfs_status = NFS4ERR_SERVERFAULT;
+			T_EXIT0(nfs_status);
+			goto out;
+		}
+	}
+
+	if (!inline_xdr_u_int32_t(da_addr_body, &ds_count)) {
+		LogCrit(COMPONENT_PNFS,
+			"Failed to encode ds_count: %u", ds_count);
+		nfs_status = NFS4ERR_SERVERFAULT;
+		T_EXIT0(nfs_status);
+		goto out;
+	}
+
+	nfs_status = FSAL_encode_v4_multipath(da_addr_body, hosts_nmemb, hosts);
+	if (nfs_status != NFS4_OK) {
+		LogCrit(COMPONENT_PNFS, "FSAL_encode_v4_multipath failed, :%x",
+			nfs_status);
+		T_EXIT0(nfs_status);
+		goto out;
+	}
+
+	T_EXIT0(nfs_status);
+out:
+	gsh_free(stripes);
+	gsh_free(hosts);
+
+	return nfs_status;
+}
+
+/**
+ * @brief Get list of available devices
+ *
+ * We do not support listing devices and just set EOF without doing
+ * anything.
+ *
+ * @param[in]     export_pub Export handle
+ * @param[in]     type      Type of layout to get devices for
+ * @param[in]     cb        Function taking device ID halves
+ * @param[in,out] res       In/out and output arguments of the function
+ *
+ * @return Valid error codes in RFC 5661, pp. 365-6.
+ */
+
+static nfsstat4
+kvsfs_getdevicelist(struct fsal_export *export_pub,
+		     layouttype4 type,
+		     void *opaque,
+		     bool (*cb)(void *opaque,
+			const uint64_t id),
+		     struct fsal_getdevicelist_res *res)
+{
+	res->eof = true;
+	return NFS4_OK;
+}
+
+void
+export_ops_pnfs(struct export_ops *ops)
+{
+	ops->getdevicelist = kvsfs_getdevicelist;
+	ops->fs_layouttypes = kvsfs_fs_layouttypes;
+	ops->fs_layout_blocksize = kvsfs_fs_layout_blocksize;
+	ops->fs_maximum_segments = kvsfs_fs_maximum_segments;
+	ops->fs_loc_body_size = kvsfs_fs_loc_body_size;
+}
+void fsal_ops_pnfs(struct fsal_ops *ops)
+{
+	ops->getdeviceinfo = kvsfs_getdeviceinfo;
+	ops->fs_da_addr_size = kvsfs_fs_da_addr_size;
+}
+/**
+ * @brief Grant a layout segment.
+ *
+ * Grant a layout on a subset of a file requested.  As a special case,
+ * lie and grant a whole-file layout if requested, because Linux will
+ * ignore it otherwise.
+ *
+ * @param[in]     obj_pub  Public object handle
+ * @param[in]     req_ctx  Request context
+ * @param[out]    loc_body An XDR stream to which the FSAL must encode
+ *                         the layout specific portion of the granted
+ *                         layout segment.
+ * @param[in]     arg      Input arguments of the function
+ * @param[in,out] res      In/out and output arguments of the function
+ *
+ * @return Valid error codes in RFC 5661, pp. 366-7.
+ */
+
+
+static nfsstat4
+kvsfs_layoutget(struct fsal_obj_handle *obj_hdl,
+		 struct req_op_context *req_ctx,
+		 XDR *loc_body,
+		 const struct fsal_layoutget_arg *arg,
+		 struct fsal_layoutget_res *res)
+{
+	struct kvsfs_fsal_module *kvsfs_fsal = NULL;
+	struct kvsfs_fsal_obj_handle *myself;
+	struct kvsfs_file_handle kvsfs_ds_handle;
+	uint32_t stripe_unit = 0;
+	nfl_util4 util = 0;
+	struct pnfs_deviceid deviceid = DEVICE_ID_INIT_ZERO(FSAL_ID_EXPERIMENTAL);
+	nfsstat4 nfs_status = 0;
+	struct gsh_buffdesc ds_desc;
+	kvsfs_fsal = (struct kvsfs_fsal_module *)
+		container_of(obj_hdl->fsal, struct kvsfs_fsal_module, fsal);
+	struct kvsfs_pnfs_mds_ctx *mds_ctx = kvsfs_fsal->mds_ctx;
+
+	T_ENTER(">>> (%p, %p)", obj_hdl, arg);
+
+	if (mds_ctx->pnfs_role < KVSFS_PNFS_MDS) {
+		LogCrit(COMPONENT_PNFS,
+			"MDS operation on Non-MDS export");
+		T_EXIT0(mds_ctx->pnfs_role);
+		return NFS4ERR_PNFS_NO_LAYOUT;
+	}
+
+	/* We support only SUPPORTED_LAYOUT_TYPE (i.e. LAYOUT4_NFSV4_1_FILES)
+	 * layouts */
+
+	if (arg->type != SUPPORTED_LAYOUT_TYPE) {
+		LogCrit(COMPONENT_PNFS,
+			"Unsupported layout type: %x",
+			arg->type);
+		T_EXIT0(arg->type);
+		return NFS4ERR_UNKNOWN_LAYOUTTYPE;
+	}
+
+	/* Get basic information on the file and calculate the dimensions
+	 *of the layout we can support. */
+
+	myself = container_of(obj_hdl,
+			      struct kvsfs_fsal_obj_handle,
+			      obj_handle);
+
+	/* TODO: permission check for res->segment.io_mode against to the
+	 * current export and file handle
+	 * This check should be performed against the open's permission that
+	 * client requested earlier, and to implement it will need support
+	 * for global open table.
+	 */
+	// Note: We give layout of the whole file
+	res->segment.offset = 0;
+	res->segment.length = NFS4_UINT64_MAX;
+
+	/* TODO: Mark this file layout is locked so no further layoutget
+	 * should be granted and error NFS4ERR_LAYOUTTRYLATER should be returned.
+	 */
+	res->return_on_close = true;
+
+	/* We grant only one segment, and we want
+	 * it back when the file is closed. */
+	res->last_segment = true;
+
+	// Back channel based notification is unavailable for now
+	res->signal_available = false;
+
+	stripe_unit = mds_ctx->mds->stripe_unit;
+	 util |= stripe_unit | NFL4_UFLG_COMMIT_THRU_MDS;
+
+	if ((util & NFL4_UFLG_STRIPE_UNIT_SIZE_MASK) != stripe_unit) {
+		LogEvent(COMPONENT_PNFS,
+			 "Invalid stripe_unit %u, truncated to %u",
+			 stripe_unit, util);
+		T_EXIT0(util);
+		return NFS4ERR_SERVERFAULT;
+	}
+
+	deviceid.fsal_id = FSAL_ID_EXPERIMENTAL;
+	LogDebug(COMPONENT_PNFS,
+		 "devid nodeAddr %016"PRIx64,
+		 deviceid.devid);
+
+	memcpy(&kvsfs_ds_handle,
+	       myself->handle, sizeof(struct kvsfs_file_handle));
+
+	nfs_status = gtbl_layout_add_elem(&kvsfs_ds_handle);
+	if (nfs_status != NFS4_OK) {
+		LogCrit(COMPONENT_PNFS,
+			"Failed to add nfsv4_1_file_layout: %x", nfs_status);
+		T_EXIT0(nfs_status);
+		goto relinquish;
+	}
+
+	ds_desc.addr = &kvsfs_ds_handle;
+	ds_desc.len = sizeof(struct kvsfs_file_handle);
+
+	nfs_status = FSAL_encode_file_layout(
+			loc_body,
+			&deviceid,
+			util,
+			0,
+			0,
+			&req_ctx->ctx_export->export_id,
+			1,
+			&ds_desc);
+	if (nfs_status) {
+		LogCrit(COMPONENT_PNFS,
+			"Failed to encode nfsv4_1_file_layout.");
+		T_EXIT0(nfs_status);
+		gtbl_layout_rmv_elem(&kvsfs_ds_handle);
+		goto relinquish;
+	}
+
+	T_EXIT0(nfs_status);
+relinquish:
+
+	return nfs_status;
+}
+
+/**
+ * @brief Potentially return one layout segment
+ *
+ * Since we don't make any reservations, in this version, or get any
+ * pins to release, always succeed
+ *
+ * @param[in] obj_pub  Public object handle
+ * @param[in] req_ctx  Request context
+ * @param[in] lrf_body Nothing for us
+ * @param[in] arg      Input arguments of the function
+ *
+ * @return Valid error codes in RFC 5661, p. 367.
+ */
+
+static nfsstat4
+kvsfs_layoutreturn(struct fsal_obj_handle *obj_hdl,
+		    struct req_op_context *req_ctx,
+		    XDR *lrf_body,
+		    const struct fsal_layoutreturn_arg *arg)
+{
+	struct kvsfs_fsal_obj_handle *myself;
+	/* The private 'full' object handle */
+
+	T_ENTER(">>> (%p, %p)", obj_hdl, arg);
+
+	/* Sanity check on type */
+	if (arg->lo_type != LAYOUT4_NFSV4_1_FILES) {
+		LogCrit(COMPONENT_PNFS,
+			"Unsupported layout type: %x",
+			arg->lo_type);
+		T_EXIT0(NFS4ERR_UNKNOWN_LAYOUTTYPE);
+	return NFS4ERR_UNKNOWN_LAYOUTTYPE;
+	}
+
+	myself = container_of(obj_hdl,
+			      struct kvsfs_fsal_obj_handle,
+			      obj_handle);
+
+	/* TODO: Unlock the layout lock from this file handle */
+	gtbl_layout_rmv_elem((const struct kvsfs_file_handle *) myself->handle);
+
+	T_EXIT0(NFS4_OK);
+	return NFS4_OK;
+}
+
+/**
+ * @brief Commit a segment of a layout
+ *
+ * This function is called once on every segment of a layout.  The
+ * FSAL may avoid being called again after it has finished all tasks
+ * necessary for the commit by setting res->commit_done to true.
+ *
+ * @param[in]     obj_hdl  Public object handle
+ * @param[in]     req_ctx  Request context
+ * @param[in]     lou_body An XDR stream containing the layout
+ *                         type-specific portion of the LAYOUTCOMMIT
+ *                         arguments.
+ * @param[in]     arg      Input arguments of the function
+ * @param[in,out] res      In/out and output arguments of the function
+ *
+ * @return Valid error codes in RFC 5661, p. 366.
+ */
+
+static nfsstat4
+kvsfs_layoutcommit(struct fsal_obj_handle *obj_hdl,
+		    struct req_op_context *req_ctx,
+		    XDR *lou_body,
+		    const struct fsal_layoutcommit_arg *arg,
+		    struct fsal_layoutcommit_res *res)
+{
+	struct kvsfs_fsal_obj_handle *myself;
+	/* The private 'full' object handle */
+	// struct kvsfs_file_handle *kvsfs_handle;
+
+	T_ENTER(">>> (%p, %p)", obj_hdl, arg);
+
+	/* Sanity check on type */
+	if (arg->type != LAYOUT4_NFSV4_1_FILES) {
+		LogCrit(COMPONENT_PNFS,
+			"Unsupported layout type: %x",
+			arg->type);
+		T_EXIT0(NFS4ERR_UNKNOWN_LAYOUTTYPE);
+		return NFS4ERR_UNKNOWN_LAYOUTTYPE;
+	}
+
+	myself =
+		container_of(obj_hdl,
+			     struct kvsfs_fsal_obj_handle,
+			     obj_handle);
+	// kvsfs_handle = myself->handle;
+	gtbl_layout_rmv_elem(myself->handle);
+
+	/** @todo: here, add code to actually commit the layout */
+	res->size_supplied = false;
+	res->commit_done = true;
+
+	T_EXIT0(NFS4_OK);
+	return NFS4_OK;
+}
+
+
+void
+handle_ops_pnfs(struct fsal_obj_ops *ops)
+{
+	ops->layoutget = kvsfs_layoutget;
+	ops->layoutreturn = kvsfs_layoutreturn;
+	ops->layoutcommit = kvsfs_layoutcommit;
+}
+


### PR DESCRIPTION
# EOS-12238: pNFS: MDS: Add preliminary support for multiple layout on same file object

## Problem Description
EOS-10912 adds support for multiple DS with multi node. After this, we will be giving layout of a whole file to a client, but a layoutget conflict detection approach should be in place so that multiple layouts can not be given for same file object simultaneously, as in the absence of global file open state, this will cause data corruption if multiple writes from multiple clients/processes are performed in parallel. This task will be used to implement the rudimentary enforcement support for this cause. As discussed in the team 2's scrum today, we will use an in-memory hash table for filesystem objects to track active layouts. When this design will be used later to support global open states, then we can stop using this layout specific enforcement.

## Solution Overview
1) Add support for in-memory hash table for CORTXFS FSAL and associated APIs
2) Add support for global layout table
3) Track granted layouts based on the file handle and remove it when file closed/layout returned
4) Detect existing layouts for same file and reject layoutget requests

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_




        EOS-12238: pNFS: MDS: Add preliminary support for multiple layout on same file object

        Branch: EOS-12238
        List of added/modified/deleted files:
                new file:   kvsfs-ganesha/src/FSAL/FSAL_KVSFS/fsal_global_tables.c
                modified:   kvsfs-ganesha/src/FSAL/FSAL_KVSFS/fsal_internal.h
                modified:   kvsfs-ganesha/src/FSAL/FSAL_KVSFS/handle.c
                modified:   kvsfs-ganesha/src/FSAL/FSAL_KVSFS/main.c
                modified:   kvsfs-ganesha/src/FSAL/FSAL_KVSFS/mds.c

        Change description:
                1) Add support for in-memory hash table for CORTXFS FSAL and associated APIs
                2) Add support for global layout table
                3) Track granted layouts based on the file handle and remove it when file closed/layout returned
                4) Detect existing layouts for same file and reject layoutget requests

        Unit test (on LABVM):
                pNFS two VM dual role/one MDS, one DS test using provisioning and mero multi node, try to get layout multiple
                non-pNFS IO, UT

        Current change TODO:
                Implement timer thread to detect expired layouts and clean them
                Support for global open and layouts states instead of only current file handles
                Add support for references for hash elements, and use of ref. with provision for caller's ctx and async free

