### PR TITLE
EOS-11994: CORTX-NFS Replace clovis with motr.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Support for different file access protocols (like SAMBA, NFS etc.) to Seagate CO
 
 Install motr:
 - Latest Motr rpms (`motr` and `motr-devel`) should be installed. Take the latest rpm from this [page](http://cortx-storage.colo.seagate.com/releases/eos/github/dev/rhel-7.7.1908/motr_last_successful/)
-- `m0singlenode` service should be up and running before running nfs ganesha with motr/clovis
+- `m0singlenode` service should be up and running before running nfs ganesha with motr
 
 Install NFS Ganesha:
 * Install jemalloc (`yum install jemalloc`).
@@ -93,8 +93,8 @@ kvs_fid = <0x780000000000000b:1>
 - Create the Index use by CORTXFS and listed in cortxfs.ini as `kvs_fid`
 
 ```sh
-$ sudo m0clovis --help
-Usage: m0clovis options...
+$ sudo m0mt --help
+Usage: m0mt options...
 
 where valid options are
 
@@ -103,12 +103,12 @@ where valid options are
 	  -l     string: Local endpoint address
 	  -h     string: HA address
 	  -f     string: Process FID
-	  -p     string: Profile options for Clovis
+	  -p     string: Profile options for Motr client
 ```
 Use values for the options from `/etc/cortxfs.d/cortxfs.ini`. For the sample configuration given above, this is how command should look like
 
 ```sh
-$ m0clovis -l 172.16.2.132@tcp:12345:44:301 \
+$ m0mt -l 172.16.2.132@tcp:12345:44:301 \
 		-h 172.16.2.132@tcp:12345:45:1 \
 		-p '0x7000000000000001:1' \
 		-f '0x7200000000000000:0'\

--- a/dsal/design/dsal_io.h
+++ b/dsal/design/dsal_io.h
@@ -36,7 +36,7 @@ struct dsal_os;
 
 /** An object in OPEN state.
  * Depending on the backend implementation, it can be a POSIX file descriptor
- * or a runtime object (Clovis) or simply an FID (no runtime states).
+ * or a runtime object (Motr) or simply an FID (no runtime states).
  */
 struct dsal_obj;
 

--- a/dsal/src/CMakeLists.txt
+++ b/dsal/src/CMakeLists.txt
@@ -98,7 +98,7 @@ if(USE_CORTX_STORE)
   find_library(HAVE_CORTX motr)
   check_library_exists(
 	motr
-	m0_clovis_init
+	m0_client_init
 	""
 	HAVE_CORTX
 	)

--- a/dsal/src/include/internal/cortx/cortx_dstore.h
+++ b/dsal/src/include/internal/cortx/cortx_dstore.h
@@ -19,7 +19,7 @@
  */
 
 /*
- *This CORTX specific implementation is based on m0_clovis's object entity.
+ *This CORTX specific implementation is based on m0_client's object entity.
  */
 
 #ifndef _CORTX_DSTORE_H

--- a/dsal/src/test/dsal_test_basic.c
+++ b/dsal/src/test/dsal_test_basic.c
@@ -352,7 +352,7 @@ static int test_write_read_validate(struct dstore_obj *obj,
 	rc = test_issue_read(obj, read_buf, r_size, r_offset);
 
 	if ( rc == -ENOENT ) {
-		/* Mero is not able to handle the case where some part of object
+		/* Motr is not able to handle the case where some part of object
 		 * have not been written or created. For that it returns -ENOENT
 		 * and zeroed out the data for all the read block even though
 		 * some of them are available and we should get valid data for
@@ -458,7 +458,7 @@ static void test_write_read_aligned(void **state)
  *	Check return code for read
  *	1. If it return rc = 0, verify the data integrity against written data.
  *	2.rc = -ENOENT
- *	Mero is not able to handle the case where some part of object have
+ *	Motr is not able to handle the case where some part of object have
  *	not been written or created. For that it returns -ENOENT and zeroed out
  *	the data for all the read block even though some of them are available
  *	and we should get valid data for them atleast. For such case, this is

--- a/kvsfs-ganesha/src/FSAL/FSAL_KVSFS/conf/nfs_setup.sh
+++ b/kvsfs-ganesha/src/FSAL/FSAL_KVSFS/conf/nfs_setup.sh
@@ -89,12 +89,12 @@ function motr_lib_init {
 	log "Initializing motr_lib..."
 
 	# Create motr_lib global idx
-	run m0clovis -l $LOC_EP -h $HA_EP -p $PROFILE -f $PROC_FID index create\
+	run m0mt -l $LOC_EP -h $HA_EP -p $PROFILE -f $PROC_FID index create\
 		"$KVS_GLOBAL_FID"
 	[ $? -ne 0 ] && die "Failed to Initialise motr_lib Global index"
 
 	# Create motr_lib fs_meta idx
-	run m0clovis -l $LOC_EP -h $HA_EP -p $PROFILE -f $PROC_FID index create\
+	run m0mt -l $LOC_EP -h $HA_EP -p $PROFILE -f $PROC_FID index create\
 		"$KVS_NS_META_FID"
 	[ $? -ne 0 ] && die "Failed to Initialise motr_lib fs_meta index"
 }
@@ -303,9 +303,9 @@ function cortx_nfs_cleanup {
 	systemctl status nfs-ganesha > /dev/null && systemctl stop nfs-ganesha
 
 	# Drop index if previosly created
-	run m0clovis -l $LOC_EP -h $HA_EP -p $PROFILE -f $PROC_FID index drop\
+	run m0mt -l $LOC_EP -h $HA_EP -p $PROFILE -f $PROC_FID index drop\
 		"$KVS_GLOBAL_FID"
-	run m0clovis -l $LOC_EP -h $HA_EP -p $PROFILE -f $PROC_FID index drop\
+	run m0mt -l $LOC_EP -h $HA_EP -p $PROFILE -f $PROC_FID index drop\
 		"$KVS_NS_META_FID"
 
 	# Restore ganesha.conf, remove export entries.

--- a/kvsfs-ganesha/src/FSAL/FSAL_KVSFS/conf/nfs_setup_legacy.sh
+++ b/kvsfs-ganesha/src/FSAL/FSAL_KVSFS/conf/nfs_setup_legacy.sh
@@ -57,12 +57,12 @@ function motr_lib_init {
 	log "Initializing motr_lib..."
 
 	# Create motr_lib global idx
-	run m0clovis -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
+	run m0mt -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
 		-f $PROC_FID index create "$KVS_GLOBAL_FID"
 	[ $? -ne 0 ] && die "Failed to Initialise motr_lib Global index"
 
 	# Create motr_lib fs_meta idx
-	run m0clovis -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
+	run m0mt -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
 		-f $PROC_FID index create "$KVS_NS_META_FID"
 	[ $? -ne 0 ] && die "Failed to Initialise motr_lib fs_meta index"
 }
@@ -238,9 +238,9 @@ function cortx_nfs_cleanup {
 	systemctl status nfs-ganesha > /dev/null && systemctl stop nfs-ganesha
 
 	# Drop index if previosly created
-	run m0clovis -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
+	run m0mt -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
 		-f $PROC_FID index drop "$KVS_GLOBAL_FID"
-	run m0clovis -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
+	run m0mt -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
 		-f $PROC_FID index drop "$KVS_NS_META_FID"
 
 	# Delete export entries

--- a/nsal/src/CMakeLists.txt
+++ b/nsal/src/CMakeLists.txt
@@ -145,7 +145,7 @@ if(USE_KVS_CORTX OR USE_MOTR_STORE)
   find_library(HAVE_MOTR motr)
   check_library_exists(
 	motr
-	m0_clovis_init
+	m0_client_init
 	""
 	HAVE_MOTR
 	)

--- a/nsal/src/common/motr/m0common.h
+++ b/nsal/src/common/motr/m0common.h
@@ -33,9 +33,9 @@
 #include <ini_config.h>
 
 #include <kvstore.h>
-#include "clovis/clovis.h"
-#include "clovis/clovis_internal.h"
-#include "clovis/clovis_idx.h"
+#include "motr/client.h"
+#include "motr/client_internal.h"
+#include "motr/idx.h"
 #include <debug.h>
 
 #ifdef ENABLE_DASSERT
@@ -50,23 +50,23 @@
 /* TODO:PERF:
  *	Performance of key iterators can be improved by:
  *	1. Usage of prefetch.
- *	2. Async Clovis calls.
+ *	2. Async Motr calls.
  *	3. Piggyback data for records.
  *	The features can be implemented without significant changes in
  *	the caller code and mostly isolated in the m0common module.
  *
  *	1. The key prefetch feature requires an additional argument to specify
- *	the amount of records to retrieve in a NEXT clovis call.
+ *	the amount of records to retrieve in a NEXT motr call.
  *	Then, key_iter_next walks over the prefetched records and issues
  *	a NEXT call after the last portion of records was processed by the user.
  *
- *	2. The async clovis calls feature can be used to speed up the case
+ *	2. The async motr calls feature can be used to speed up the case
  *	where the time of records processing by the caller is comparable with
- *	the time needed to receive next bunch of records from Clovis.
+ *	the time needed to receive next bunch of records from Motr.
  *	In this case a initial next call synchronously gets a bunch of records,
  *	and then immediately issues an asynchronous NEXT call.
  *	The consequent next call waits for the issued records,
- *	and again issues a NEXT call to clovis. In conjunction with the prefetch
+ *	and again issues a NEXT call to motr. In conjunction with the prefetch
  *	feature, it can help to speed up readdir() by issuing NEXT (dentry)
  *	and GET (inode attrs) concurrently.
  *
@@ -74,7 +74,7 @@
  *	the iterator can issue a GET call to get the inode attirbutes of
  *	prefetched dentries along with the next portion of NEXT dentries.
  *	So that, we can get a chunk of dentries and the attributes of the
- *	previous chunck witin a single clovis call.
+ *	previous chunck witin a single motr call.
  *	However, this feature make sense only for the recent version of
  *	nfs-ganesha where a FSAL is resposible for filling in attrlist
  *	(the current version calls fsal_getattr() instead of it).

--- a/nsal/src/include/internal/cortx/cortx_kvstore.h
+++ b/nsal/src/include/internal/cortx/cortx_kvstore.h
@@ -19,7 +19,7 @@
  */
 
 /*
- * This CORTX specific implementation is based on m0_clovis's index entity.
+ * This CORTX specific implementation is based on m0_client's index entity.
  */
 
 #ifndef _CORTX_KVSTORE_H

--- a/nsal/src/kvstore/plugins/cortx/cortx_kvstore.c
+++ b/nsal/src/kvstore/plugins/cortx/cortx_kvstore.c
@@ -19,7 +19,7 @@
 
 /*
  * This file contains APIs which implement NSAL's KVStore framework,
- * on top of cortx clovis index APIs.
+ * on top of cortx motr index APIs.
  */
  
 #include "internal/cortx/cortx_kvstore.h"
@@ -55,7 +55,7 @@ int cortx_kvs_index_create(const kvs_idx_fid_t *fid, struct kvs_idx *index)
 {
         int rc;
 	struct m0_uint128 mfid = M0_UINT128(0, 0);
-	struct m0_clovis_idx *idx = NULL;
+	struct m0_idx *idx = NULL;
 	kvs_idx_fid_t gfid;
 
 	index->index_priv = NULL;
@@ -85,7 +85,7 @@ int cortx_kvs_index_create(const kvs_idx_fid_t *fid, struct kvs_idx *index)
 		goto out;
 	}
 
-	/** Use KVStore index's priv to track Motr clovis index */
+	/** Use KVStore index's priv to track Motr motr index */
 	index->index_priv = idx;
 out:
         return rc;
@@ -112,7 +112,7 @@ int cortx_kvs_index_open(const kvs_idx_fid_t *fid, struct kvs_idx *index)
 {
 	int rc;
 	struct m0_uint128 mfid = M0_UINT128(0, 0);
-	struct m0_clovis_idx *idx = NULL;
+	struct m0_idx *idx = NULL;
 	kvs_idx_fid_t gfid;
 
 	index->index_priv = NULL;
@@ -148,7 +148,7 @@ out:
 
 int cortx_kvs_index_close(struct kvs_idx *index)
 {
-	struct m0_clovis_idx *idx = (struct m0_clovis_idx *)index->index_priv;
+	struct m0_idx *idx = (struct m0_idx *)index->index_priv;
 
         m0idx_close(idx);
 

--- a/scripts/motr_lib_init.sh
+++ b/scripts/motr_lib_init.sh
@@ -71,20 +71,20 @@ prepare_index() {
 	[ -n "$USE_IDX" ] && return
  
 	# Drop indexes
-	m0clovis -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
+	m0mt -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
 		-f $PROC_FID index drop "$KVS_GLOBAL_FID" > /dev/null 2>&1
 	[ $? -ne 0 ] && die "Failed to drop Global index"
 
-	m0clovis -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
+	m0mt -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
 		-f $PROC_FID index drop "$KVS_NS_META_FID" > /dev/null 2>&1
 	[ $? -ne 0 ] && die "Failed to drop NS_META index"
 
 	# Create indexes
-	m0clovis -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
+	m0mt -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
 		-f $PROC_FID index create "$KVS_GLOBAL_FID" > /dev/null 2>&1
 	[ $? -ne 0 ] && die "Failed to create Global index"
 
-	m0clovis -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
+	m0mt -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
 		-f $PROC_FID index create "$KVS_NS_META_FID" > /dev/null 2>&1
 	[ $? -ne 0 ] && die "Failed to create NS_META index"
 

--- a/utils/c-utils/src/cortx/m0common.h
+++ b/utils/c-utils/src/cortx/m0common.h
@@ -36,14 +36,14 @@
 #include <pthread.h>
 #include <dirent.h>
 
-#include "clovis/clovis.h"
-#include "clovis/clovis_internal.h"
-#include "clovis/clovis_idx.h"
+#include "motr/client.h"
+#include "motr/client_internal.h"
+#include "motr/idx.h"
 #include "lib/thread.h"
 #include <cortx/helpers.h>
 #include <motr/helpers/helpers.h>
 
-struct clovis_io_ctx {
+struct motr_io_ctx {
 	struct m0_indexvec ext;
 	struct m0_bufvec   data;
 	struct m0_bufvec   attr;
@@ -54,10 +54,10 @@ enum {
 };
 
 /* To be passed as argument */
-extern struct m0_clovis_realm     clovis_uber_realm;
+extern struct m0_realm     motr_uber_realm;
 
-extern pthread_once_t clovis_init_once;
-extern bool clovis_init_done;
+extern pthread_once_t motr_init_once;
+extern bool motr_init_done;
 extern __thread struct m0_thread m0thread;
 extern __thread bool my_init_done;
 
@@ -65,26 +65,26 @@ extern pthread_t m0init_thread;
 extern struct collection_item *conf;
 
 extern struct m0_fid ifid;
-extern struct m0_clovis_idx idx;
+extern struct m0_idx idx;
 
-extern char *clovis_local_addr;
-extern char *clovis_ha_addr;
-extern char *clovis_prof;
-extern char *clovis_proc_fid;
-extern char *clovis_index_dir;
+extern char *motr_local_addr;
+extern char *motr_ha_addr;
+extern char *motr_prof;
+extern char *motr_proc_fid;
+extern char *motr_index_dir;
 extern char *ifid_str;
 
-/* Clovis Instance */
-extern struct m0_clovis	  *clovis_instance;
+/* Motr Instance */
+extern struct m0_client	  *motr_instance;
 
-/* Clovis container */
-extern struct m0_clovis_container clovis_container;
+/* Motr container */
+extern struct m0_container motr_container;
 
-/* Clovis Configuration */
-extern struct m0_clovis_config	clovis_conf;
+/* Motr Configuration */
+extern struct m0_config	motr_conf;
 extern struct m0_idx_dix_config	dix_conf;
 
-extern struct m0_clovis_realm     clovis_uber_realm;
+extern struct m0_realm     motr_uber_realm;
 
 extern struct m0_ufid_generator ufid_generator;
 
@@ -96,8 +96,8 @@ extern struct m0_ufid_generator ufid_generator;
 		return -EINVAL; })
 
 void m0kvs_do_init(void);
-int get_clovis_conf(struct collection_item *cfg);
+int get_motr_conf(struct collection_item *cfg);
 void log_config(void);
-int init_clovis(void);
+int init_motr(void);
 
 #endif

--- a/utils/c-utils/src/include/cortx/helpers.h
+++ b/utils/c-utils/src/include/cortx/helpers.h
@@ -30,9 +30,9 @@
 #include <ini_config.h>
 #include <utils.h>
 
-#include "clovis/clovis.h"
-#include "clovis/clovis_internal.h"
-#include "clovis/clovis_idx.h"
+#include "motr/client.h"
+#include "motr/client_internal.h"
+#include "motr/idx.h"
 
 #include "object.h" /* obj_id_t */
 
@@ -52,8 +52,8 @@ struct m0kvs_list {
 struct m0kvs_key_iter {
 	struct m0_bufvec key;
 	struct m0_bufvec val;
-	struct m0_clovis_op *op;
-	struct m0_clovis_idx *index;
+	struct m0_op *op;
+	struct m0_idx *index;
 	int rcs[1];
 	bool initialized;
 };
@@ -84,23 +84,23 @@ int m0kvs_key_prefix_exists(void *ctx, const void *kprefix, size_t klen,
 /* TODO:PERF:
  *	Performance of key iterators can be improved by:
  *	1. Usage of prefetch.
- *	2. Async Clovis calls.
+ *	2. Async Motr calls.
  *	3. Piggyback data for records.
  *	The features can be implemented without significant changes in
  *	the caller code and mostly isolated in the m0common module.
  *
  *	1. The key prefetch feature requires an additional argument to specify
- *	the amount of records to retrieve in a NEXT clovis call.
+ *	the amount of records to retrieve in a NEXT motr call.
  *	Then, key_iter_next walks over the prefetched records and issues
  *	a NEXT call after the last portion of records was processed by the user.
  *
- *	2. The async clovis calls feature can be used to speed up the case
+ *	2. The async motr calls feature can be used to speed up the case
  *	where the time of records processing by the caller is comparable with
- *	the time needed to receive next bunch of records from Clovis.
+ *	the time needed to receive next bunch of records from Motr.
  *	In this case a initial next call synchronously gets a bunch of records,
  *	and then immediately issues an asynchronous NEXT call.
  *	The consequent next call waits for the issued records,
- *	and again issues a NEXT call to clovis. In conjunction with the prefetch
+ *	and again issues a NEXT call to motr. In conjunction with the prefetch
  *	feature, it can help to speed up readdir() by issuing NEXT (dentry)
  *	and GET (inode attrs) concurrently.
  *
@@ -108,7 +108,7 @@ int m0kvs_key_prefix_exists(void *ctx, const void *kprefix, size_t klen,
  *	the iterator can issue a GET call to get the inode attirbutes of
  *	prefetched dentries along with the next portion of NEXT dentries.
  *	So that, we can get a chunk of dentries and the attributes of the
- *	previous chunck witin a single clovis call.
+ *	previous chunck witin a single motr call.
  *	However, this feature make sense only for the recent version of
  *	nfs-ganesha where a FSAL is resposible for filling in attrlist
  *	(the current version calls fsal_getattr() instead of it).
@@ -155,7 +155,7 @@ int m0kvs_list_add(struct m0kvs_list *kvs_buf, void *buf, size_t buf_len,
                    int index);
 
 /*****************************************************************************/
-/** Open a Clovis object.
+/** Open a Motr object.
  * This function writes a new in-memory object into the provided "pobj"
  * storage, and it does not do any checks regarding the following topics:
  *	- (1) Existence of the object. Behavior of the function is the same as
@@ -179,17 +179,17 @@ int m0kvs_list_add(struct m0kvs_list *kvs_buf, void *buf, size_t buf_len,
  *		 representation of the object with the given FID.
  * @return 0 or -errno in case of failure.
  */
-int m0store_obj_open(const obj_id_t *id, struct m0_clovis_obj *pobj);
+int m0store_obj_open(const obj_id_t *id, struct m0_obj *pobj);
 
-/** Close a Clovis object.
- * This function closes an open Clovis object. It does not provide
+/** Close a Motr object.
+ * This function closes an open Motr object. It does not provide
  * any guarantees regarding the double-free problem. It is up
  * to the caller to guarantee the proper sequence of open/close calls.
  * An attempt to close an already closed object is UB.
  * It may either cause an m0_panic, SIGSEGV or it may do nothing.
- * @param[inout] obj Clovis object that has been opened.
+ * @param[inout] obj Motr object that has been opened.
  */
-void m0store_obj_close(struct m0_clovis_obj *obj);
+void m0store_obj_close(struct m0_obj *obj);
 
 /*****************************************************************************/
 
@@ -248,26 +248,26 @@ static inline void m0_fid_copy(struct m0_uint128 *src, struct m0_uint128 *dest)
  * Note: The caller should release the resources associated with the handle
  * by calling m0idx_close.
  * @param fid In FID 
- * @param index Out on success a valid initialized clovis index is returned.
+ * @param index Out on success a valid initialized motr index is returned.
  */
-int m0idx_create(const struct m0_uint128 *fid, struct m0_clovis_idx **index);
+int m0idx_create(const struct m0_uint128 *fid, struct m0_idx **index);
 
-/** Delete clovis index instance.
+/** Delete motr index instance.
  * @param fid In FID 
- * @param index Out on success a valid initialized clovis index is returned.
+ * @param index Out on success a valid initialized motr index is returned.
  */
 int m0idx_delete(const struct m0_uint128 *fid);
 
-/** Initialize clovis index instance.
+/** Initialize motr index instance.
  * @param fid In FID 
- * @param index Out on success a valid initialized clovis index is returned.
+ * @param index Out on success a valid initialized motr index is returned.
  */
-int m0idx_open(const struct m0_uint128 *fid, struct m0_clovis_idx **index);
+int m0idx_open(const struct m0_uint128 *fid, struct m0_idx **index);
 
-/** Finalize clovis index instance.
+/** Finalize motr index instance.
  * @param index Index to be finalized.
  */
-void m0idx_close(struct m0_clovis_idx *index);
+void m0idx_close(struct m0_idx *index);
 
 /* @todo FS mgmt work will revisit the need of this function */
 const char * m0_get_gfid();


### PR DESCRIPTION
Changes made for Clovis Name in cortx-posix Project

Generic Notes :
"_clovis_" changed to "_"
"clovis/clovis" changed to "motr/client"
"m0_clovis_init" changed to "m0_client_init"
"m0_clovis_fini" changed to "m0_client_fini"
"get_clovis_conf" changed to "get_motr_conf"
m0clovis changed to m0mt
motr_conf.cc changed to motr_conf.mc
clovis changed to motr
m0_clovis_layout_id changed to m0_client_layout_id

 sudo ./scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

EFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.logs
Total tests  = 4
Tests passed = 3
Tests failed = 1

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 12
Tests passed = 12
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_efs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0