### PR TITLE
 EOS-12089 : NFS: mero singlenode: ganesha service is failing to start due to panic

### DIFF
--- a/scripts/motr_lib_init.sh
+++ b/scripts/motr_lib_init.sh
@@ -71,20 +71,20 @@ prepare_index() {
 	[ -n "$USE_IDX" ] && return
  
 	# Drop indexes
-	m0mt -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
+	m0kv -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
 		-f $PROC_FID index drop "$KVS_GLOBAL_FID" > /dev/null 2>&1
 	[ $? -ne 0 ] && die "Failed to drop Global index"
 
-	m0mt -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
+	m0kv -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
 		-f $PROC_FID index drop "$KVS_NS_META_FID" > /dev/null 2>&1
 	[ $? -ne 0 ] && die "Failed to drop NS_META index"
 
 	# Create indexes
-	m0mt -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
+	m0kv -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
 		-f $PROC_FID index create "$KVS_GLOBAL_FID" > /dev/null 2>&1
 	[ $? -ne 0 ] && die "Failed to create Global index"
 
-	m0mt -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
+	m0kv -l $ip_add$LOC_EXPORT_ID -h $ip_add$HA_EXPORT_ID -p $PROFILE\
 		-f $PROC_FID index create "$KVS_NS_META_FID" > /dev/null 2>&1
 	[ $? -ne 0 ] && die "Failed to create NS_META index"
 


### PR DESCRIPTION
## EOS-12089 : NFS: mero singlenode: ganesha service is failing to start due to panic
https://jts.seagate.com/browse/EOS-12809

## Solution Overview
Incorrect clovis utility (m0mt) was being used for creating indexes in nfs_setup.
m0kv is the correct utility that should be used. This has been fixed in nfs_setup.sh and motr_lib_init.shts

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing 
- [x] **Documentation:** _This patch and merge request have up to date description_

## What doesn't work
nfs_setup script works fine, but the the filesystem is not exported. This is due to the PNFS related config blocks that have been added
@pratyush-seagate  @AtitaShirwaikar 

## Workarounds : 
Remove the PNFS block from ganesha.conf or from nfs_setup. After this, the filesystem is exported correctly and cthon passes.


