### PR TITLE
fix memory leak

### DIFF
--- a/experiments/xattr/approach1_async.c
+++ b/experiments/xattr/approach1_async.c
@@ -193,6 +193,7 @@ static int setAttr()
 	for (i = 0; i < CALLS; i++)
 		free(xkey[i]);
 
+    free(v1);
 	return rc;
 }
 


### PR DESCRIPTION
free the memory allocated within
the function, before returning