### PR TITLE
EOS-12583: Add test for global KVStore operations

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -24,7 +24,7 @@ execute_ut_nsal () {
 	cd $UT_LOG_ROOT/nsal
 
 	NSAL_TEST_DIR=$BUILD_DIR/build-nsal/test/ut
-	NSAL_TEST_LIST=(ut_nsal_ns_ops ut_nsal_iter_ops ut_nsal_kvtree_ops)
+	NSAL_TEST_LIST=(ut_nsal_ns_ops ut_nsal_iter_ops ut_nsal_kvtree_ops ut_global_kvs)
 
 	[ ! -d $NSAL_TEST_DIR ] && die "NSAL is not built"
 


### PR DESCRIPTION
# CORTX-POSIX Change Summary

## Problem Statement

_[EOS-12583](https://jts.seagate.com/browse/EOS-12583):_
_Ability to set a global KVStore index and related operations_

## Problem Description

_The current NSAL UT bucket do not have any tests for newly added functionality of being able to work on global index._

## Solution Overview

_Unit test for new functionality has been added, but need to invoke it as part of nsal test bucket. Added the test scenario in the NSAL test bucket_

### Companion PR
https://github.com/Seagate/cortx-nsal/pull/20

## Unit Test Cases
_NSAL UT is passing_
$ sudo ./scripts/test.sh -t nsal
[sudo] password for 744293:
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _As mentioned related test cases are passing_