### PR TITLE
EOS-14771:ADDB: Enable/Disable ADDB tracing via build script (repo cortx-posix)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -27,6 +27,7 @@ Arguments:
     -k (optional) NSAL KVSTORE backend (cortx/redis).
     -e (optional) DSAL DSTORE backend (cortx/posix).
     -d (optional) Enable/disable dassert(ON/OFF, default:ON).
+    -t (optional) Enable/disable addb based tsdb perf. profiling(ON/OFF, default:OFF).
 
 Examples:
     $0 -p ~/nfs-ganesha -- Builds CORTXFS with a custom NFS Ganesha
@@ -37,7 +38,7 @@ Examples:
 }
 
 cortxfs_parse_cmd() {
-    while getopts ":b:v:p:k:e:d:" o; do
+    while getopts ":b:v:p:k:e:d:t:" o; do
         case "${o}" in
         b)
             export CORTXFS_BUILD_VERSION="${OPTARG}_$(git rev-parse --short HEAD)"
@@ -83,6 +84,9 @@ cortxfs_parse_cmd() {
         d)
             export ENABLE_DASSERT=${OPTARG}
             ;;
+        t)
+            export ENABLE_TSDB_ADDB=${OPTARG}
+            ;;
         *)
             cortxfs_cmd_usage
             ;;
@@ -113,6 +117,7 @@ cortxfs_set_env() {
     export KVSFS_NFS_GANESHA_DIR=${KVSFS_NFS_GANESHA_DIR:-$PWD/../nfs-ganesha-cortx}
     export KVSFS_NFS_GANESHA_BUILD_DIR=${KVSFS_NFS_GANESHA_BUILD_DIR:-$CORTXFS_BUILD_ROOT/build-nfs-ganesha}
     export ENABLE_DASSERT=${ENABLE_DASSERT:-"ON"}
+    export ENABLE_TSDB_ADDB=${ENABLE_TSDB_ADDB:-"OFF"}
     export INSTALL_DIR_ROOT="/opt/seagate"
 }
 
@@ -132,6 +137,7 @@ cortxfs_print_env() {
         KVSFS_NFS_GANESHA_BUILD_DIR
         CORTXFS_SOURCE_ROOT
         ENABLE_DASSERT
+        ENABLE_TSDB_ADDB
 	INSTALL_DIR_ROOT
     )
     for i in ${myenv[@]}; do


### PR DESCRIPTION
#  EOS-14771:ADDB: Enable/Disable ADDB tracing via build script (repo cortx-posix)

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## UT

[root@ssc-vm-c-0040 /]# ./cortx-posix/scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0


## Commit Message
commit f4b1d8b7ee72b2bc9d035a66472e969b976237e0
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Sun Nov 8 21:28:57 2020 -0700

        EOS-14771:ADDB: Enable/Disable ADDB tracing via build script (repo cortx-posix)
        List of modified files:
                modified:   scripts/build.sh
        Change description:
                Introduce new build configuration flag named ENABLE_TSDB_ADDB
                to enable/disable addb based performance profiling code in
                cortxfs modules. This flag is set to on by default.
        Unit test:
                Full configure, build and install with this flag on and off.
                To on/off this build flag, update build.sh and edit the export
                line.
                Verified that addb traces from cortxfs are obeying this build
                flag correctly.
                UT was successful.
        TODO:
                The jenkins build path also includes this change, a new arg
                is added to pass this arg (-t). But this code path is yet to
                be tested.
